### PR TITLE
fix: scrape_details 最终保存兼容裸文件名，避免 FileNotFoundError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 未发布
 
 ### 修复
+- `scrape_details` 最终保存改用 `os.path.dirname(path) or "."`，`--detail-output` 传不带目录的裸文件名时不再抛 `FileNotFoundError`（与循环内及其它写文件处保持一致）
 - 修正城市码：天津 `101030100`、沈阳 `101070100`（原均误用 `101060100`）
 - `require_runtime_dependencies` 缺失依赖时同时提示 uv 和 pip 安装方式
 - `--merge` 现在会合并旧详情并落盘到 `--detail-output`（之前只合并列表，详情丢失）

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -1104,8 +1104,8 @@ def scrape_details(list_data, max_details=None, output_path=None,
         print(f"  等待 {gap:.0f}s 后抓下一个...\n")
         time.sleep(gap)
 
-    # 最终保存
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # 最终保存（dirname 为空时回退到当前目录，与循环内/其它写文件处保持一致）
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(results, f, ensure_ascii=False, indent=2)
     print(f"\n详情已保存: {output_path}")

--- a/tests/test_chrome_setup.py
+++ b/tests/test_chrome_setup.py
@@ -1,6 +1,7 @@
 import importlib.util
 import csv
 import json
+import os
 import pathlib
 import re
 import subprocess
@@ -236,6 +237,25 @@ class ChromeSetupTests(unittest.TestCase):
         self.assertEqual(rows[0]["salary_source"], "api")
         self.assertEqual(rows[0]["skill_tags"], "Python | LLM")
         self.assertEqual(rows[0]["jd"], "Build AI agents")
+
+    def test_scrape_details_final_save_handles_bare_filename(self):
+        """--detail-output 传不带目录的裸文件名时，最终保存不应崩溃。
+
+        空 jobs 列表不触发 CDP，可直接走到最终保存逻辑；此前最终保存用
+        os.makedirs(os.path.dirname(path))，dirname 为空字符串会抛
+        FileNotFoundError，丢掉收尾保存和 CSV 导出。
+        """
+        module = load_module()
+        with tempfile_profile() as paths:
+            workdir = paths["cdp_profile"]
+            workdir.mkdir(parents=True, exist_ok=True)
+            cwd = os.getcwd()
+            os.chdir(workdir)
+            try:
+                module.scrape_details({"jobs": []}, output_path="boss_details.json")
+                self.assertTrue((workdir / "boss_details.json").exists())
+            finally:
+                os.chdir(cwd)
 
     def test_setup_defaults_do_not_copy_cookies_or_kill_all_chrome(self):
         module = load_module()


### PR DESCRIPTION
Closes #2
--detail-output 传不带目录的裸文件名（如 details.json）时，最终保存调用 os.makedirs(os.path.dirname(path))，dirname 为空字符串，os.makedirs("") 抛 FileNotFoundError。崩溃发生在所有详情抓取完成之后，丢掉收尾保存提示和 CSV
导出，并以 traceback 结束。

改用 os.path.dirname(path) or "."，与循环内（第1096行）及 write_csv / write_detail_csv / flush_jobs 等其它写文件处保持一致。

补充测试 test_scrape_details_final_save_handles_bare_filename：空 jobs 列表 不触发 CDP，直接走到最终保存逻辑，验证裸文件名下不再崩溃。