### PR TITLE
docs: 优化 README SEO 关键词 + 新增英文版

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,242 @@
+# BOSS Zhipin Scraper · Job Crawler v2.0 (Chrome CDP / Plaintext Salary)
+
+> 🌐 中文文档：[README.md](./README.md)
+
+![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
+![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)
+![Version](https://img.shields.io/badge/version-2.0.0-orange.svg)
+
+A lightweight **BOSS Zhipin scraper / crawler** (a.k.a. spider) for job listings on [zhipin.com](https://www.zhipin.com). Instead of driving a heavy Selenium/Playwright browser, it connects to your **already-logged-in Chrome** via the Chrome DevTools Protocol (CDP), reuses the real session, and calls the in-page search API directly — bypassing the front-end font-based anti-scraping so you get the **plaintext salary** in every record. Output goes to JSON / CSV, plus an aggregated salary/skill analysis and a copy-paste prompt for polishing your job-application materials. Also ships as a Hermes Agent Skill.
+
+> 📌 **In one sentence**: no Selenium/Playwright — connect to your logged-in Chrome over CDP, hit the search API with the real session, get JSON/CSV with plaintext salaries, plus salary-distribution, skill-frequency stats and a résumé-optimization prompt.
+
+---
+
+## 🚀 30-Second Quick Start
+
+```bash
+# 1. Clone + install deps
+git clone https://github.com/eatmoreduck/boss-zhipin-scraper.git
+cd boss-zhipin-scraper
+pip install -r requirements.txt          # or: uv sync
+
+# 2. Launch an isolated Chrome and log in (only once; session persists)
+python3 scripts/boss_cdp_raw.py --setup-chrome
+
+# 3. Scrape + analyze
+python3 scripts/boss_cdp_raw.py --keyword "AI Agent" --city 上海 --pages 3 --analysis
+
+# 4. Generate an aggregated summary + prompt after scraping (reads the latest result)
+python3 scripts/job_summary.py
+```
+
+Right after scraping you get: salary ranges, experience requirements, top skill keywords, and a job-application optimization prompt. The prompt is based solely on the scraped job data — it never reads your local résumé file and never scores personal-job match.
+
+## ✨ Features
+
+- Plaintext salary (API mode, bypasses font-based obfuscation)
+- Dual JSON / CSV output
+- Detail-page JD scraping + skill analysis
+- Aggregated summary + copy-paste prompt after scraping
+- Incremental writes (no data loss on crash)
+- One-shot environment check + persistent isolated Chrome CDP profile
+- Multi-dimension filters (scale, funding, salary, experience, degree, industry)
+- macOS + Linux support (a Windows code path is reserved but untested — not guaranteed to work)
+
+<details>
+<summary>🔍 Why not a Selenium / Playwright crawler?</summary>
+
+- Selenium/Playwright spins up a full instrumented browser — it's heavy, has an obvious fingerprint, and is easily flagged by BOSS Zhipin's risk-control / CAPTCHA.
+- This tool connects to your own already-logged-in Chrome (via CDP), reusing a real fingerprint and session, and calls the same legitimate search API the page uses. The `salaryDesc` it returns is already plaintext — no need to parse font-obfuscated DOM salaries.
+- The result is more stable than traditional DOM-scraping crawlers and harder to flag as automated traffic.
+
+</details>
+
+## Installation
+
+### Option 1: Clone then install locally (recommended)
+
+Because `hermes skills install` may not reach GitHub directly in some environments, clone the repo first and install locally:
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/eatmoreduck/boss-zhipin-scraper.git
+cd boss-zhipin-scraper
+
+# 2. Copy into the Hermes skills directory
+mkdir -p ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts
+cp SKILL.md ~/.hermes/skills/data-science/boss-zhipin-scraper/
+cp scripts/boss_cdp_raw.py ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts/
+cp scripts/job_summary.py ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts/
+```
+
+### Option 2: One-line curl install
+
+No need to clone the whole repo — download just the files you need:
+
+```bash
+mkdir -p ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts && \
+curl -sL https://raw.githubusercontent.com/eatmoreduck/boss-zhipin-scraper/master/SKILL.md \
+  -o ~/.hermes/skills/data-science/boss-zhipin-scraper/SKILL.md && \
+curl -sL https://raw.githubusercontent.com/eatmoreduck/boss-zhipin-scraper/master/scripts/boss_cdp_raw.py \
+  -o ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts/boss_cdp_raw.py && \
+curl -sL https://raw.githubusercontent.com/eatmoreduck/boss-zhipin-scraper/master/scripts/job_summary.py \
+  -o ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts/job_summary.py
+```
+
+### Option 3: `hermes skills install` (requires direct GitHub access)
+
+```bash
+hermes skills install https://raw.githubusercontent.com/eatmoreduck/boss-zhipin-scraper/master/SKILL.md --category data-science
+```
+
+> Note: this depends on the hermes process being able to reach GitHub directly. If you hit a timeout or connection failure, use Option 1 or 2.
+
+### Verify the installation
+
+```bash
+# Check that the files exist
+ls ~/.hermes/skills/data-science/boss-zhipin-scraper/SKILL.md
+ls ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts/boss_cdp_raw.py
+ls ~/.hermes/skills/data-science/boss-zhipin-scraper/scripts/job_summary.py
+```
+
+After installing, just say in a Hermes conversation: "Search BOSS Zhipin for AI Agent jobs in Shanghai."
+
+## Use as a CLI tool
+
+You don't have to install it as a Skill — use it as a plain CLI:
+
+```bash
+# 1. Clone + install deps
+git clone https://github.com/eatmoreduck/boss-zhipin-scraper.git
+cd boss-zhipin-scraper
+pip install -r requirements.txt
+
+# 2. Start Chrome CDP
+python3 scripts/boss_cdp_raw.py --setup-chrome
+# First run won't copy your main Chrome session; log in to zhipin.com in the dedicated BOSS browser that pops up
+# setup waits for login to finish and confirms the API returns plaintext salaries
+
+# 3. Check the environment
+python3 scripts/boss_cdp_raw.py --check
+
+# Optional: real browser/API smoke test (writes no result files)
+python3 scripts/boss_cdp_raw.py --smoke-test
+
+# 4. Scrape
+python3 scripts/boss_cdp_raw.py --keyword "AI Agent" --city 上海 --pages 3 --format csv --analysis
+
+# 5. Summary + prompt after scraping
+python3 scripts/job_summary.py --top 15
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--keyword` | Search keyword (default "AI Agent") |
+| `--city` | City (Chinese name or code, default Shanghai) |
+| `--pages` | Number of pages (max 10) |
+| `--format` | json / csv; csv also exports list and detail CSVs |
+| `--detail` | Scrape detail-page JD (on by default) |
+| `--no-detail` | Do not scrape detail pages |
+| `--analysis` | Analysis report |
+| `--merge FILE` | Merge existing data (deduped by job_id) |
+| `--allow-dom-fallback` | Allow DOM extraction fallback when the API has no data; off by default, salaries may be unreliable |
+| `--check` | Environment check (CDP + deps + login state) |
+| `--smoke-test` | Run one real Chrome/CDP BOSS search API smoke test, writes no result files |
+| `--setup-chrome` | One-shot launch of Chrome CDP (persistent isolated profile) |
+| `--copy-login-state` | Manually import the main Chrome's Local State + cookie-related files into the isolated profile (never copied by default, on first run, or on repeated runs) |
+| `--reset-chrome-profile` | Rebuild the dedicated BOSS Chrome profile; clears the login state inside this dedicated browser |
+| `--no-wait-login` | With `--setup-chrome`, do not wait for login to finish |
+| `--login-timeout` | Seconds to wait for login under `--setup-chrome` (default 300) |
+| `--output` | List output path (default `~/.boss-zhipin-scraper/job-result/`) |
+| `--detail-output` | Detail output path (default `~/.boss-zhipin-scraper/job-result/`) |
+| `--cdp-port` | CDP port (default 9222) |
+| `--scale/--salary/--experience/--degree` | Filters |
+
+## Post-Scrape Summary & Prompt
+
+`scripts/job_summary.py` only reads the already-scraped `boss_jobs_*.json` and `boss_details_*.json`, does simple aggregation, and produces a copy-paste prompt. It never reads your local résumé file, pulls in no PDF dependency, and never scores a person against a job.
+
+```bash
+# Read the newest boss_jobs_*.json under the default result dir and auto-match the same-timestamp or newest detail file
+python3 scripts/job_summary.py
+
+# Specify list and detail files
+python3 scripts/job_summary.py \
+  --input ~/.boss-zhipin-scraper/job-result/boss_jobs_20260625_1200.json \
+  --details ~/.boss-zhipin-scraper/job-result/boss_details_20260625_1200.json \
+  --top 15
+
+# Only emit the prompt
+python3 scripts/job_summary.py --prompt-only
+```
+
+After installing the package you can also use the entry command:
+
+```bash
+uv run boss-summary --top 15
+```
+
+The summary covers: salary ranges, experience requirements, degree requirements, regional distribution, top companies, skill tags, frequent JD terms. The prompt asks the model to use these stats to fill in résumé keywords, suggest project-story rewrite directions, and produce an interview-prep checklist — while explicitly instructing it not to fabricate experience.
+
+## File Structure
+
+```
+boss-zhipin-scraper/
+├── SKILL.md              # Hermes Skill definition
+├── README.md             # Chinese docs
+├── README.en.md          # English docs
+├── CHANGELOG.md
+├── LICENSE
+├── pyproject.toml
+├── scripts/
+│   ├── boss_cdp_raw.py   # Main scraping script
+│   └── job_summary.py    # Post-scrape summary + prompt
+└── requirements.txt
+```
+
+## How It Works
+
+This is a Chrome-CDP-based BOSS Zhipin crawler. Core flow:
+
+1. Connect to an already-open Chrome via the Chrome DevTools Protocol (CDP)
+2. Inject JS inside the BOSS Zhipin page that calls the search API via synchronous XHR
+3. The API returns plaintext `salaryDesc`, bypassing the front-end font obfuscation
+4. The list API preserves `securityId` / `lid` context, carried into the detail page
+5. Each page is written to disk immediately, deduped by `job_id`
+
+DOM extraction is not used for the list by default, since DOM salaries may be hit by font-based obfuscation. Only when `--allow-dom-fallback` is explicitly passed will it fall back to DOM when the API returns no data.
+
+`--input ... --analysis --no-detail` first loads `--detail-output`, then the `boss_details_*.json` with the same timestamp in the same dir as the input list, and finally the newest detail file under `~/.boss-zhipin-scraper/job-result`.
+
+## Chrome Profile Security Policy
+
+`--setup-chrome` uses a persistent isolated profile by default — it neither symlinks nor copies your main Chrome data. First launch and subsequent launches only create or reuse this dedicated profile:
+
+- `~/.boss-zhipin-scraper/chrome-profile`
+
+Without an explicit `--output` or `--detail-output`, scraping results are saved under:
+
+- `~/.boss-zhipin-scraper/job-result`
+
+On first use you must log in to BOSS Zhipin manually inside this dedicated Chrome. `--setup-chrome` waits for the login to finish and uses the search API to confirm it can get plaintext `salaryDesc` before returning. The session is stored inside the dedicated profile and survives reboots; re-running `--setup-chrome` does not wipe it and does not affect your main Chrome, Gmail, GitHub, or other accounts.
+
+If you really need to import the BOSS session from your main Chrome, run explicitly:
+
+```bash
+python3 scripts/boss_cdp_raw.py --setup-chrome --copy-login-state
+```
+
+`--copy-login-state` overwrites the corresponding cookie-related files inside the isolated profile on every run; do not pass this for daily launches. It only copies `Local State` and `Default/Cookies*`, `Default/Network/Cookies*`-style cookie database files — not password stores, history, extensions, or a full profile. To wipe the dedicated browser's login state:
+
+```bash
+python3 scripts/boss_cdp_raw.py --setup-chrome --reset-chrome-profile
+```
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# BOSS直聘职位抓取工具 v2.0
+# BOSS直聘爬虫 · 职位抓取工具 v2.0（Chrome CDP / 明文薪资）
+
+> 🌐 English documentation: [README.en.md](./README.en.md)
 
 ![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)
 ![Version](https://img.shields.io/badge/version-2.0.0-orange.svg)
 
-通过 Chrome CDP 协议抓取 BOSS直聘职位数据的命令行工具 + Hermes Agent Skill。
+一个轻量的 **BOSS直聘爬虫（spider / crawler / scraper）**：通过 Chrome DevTools Protocol 连接本地已登录的 Chrome，复用真实登录态调用 zhipin.com 搜索 API，绕过前端字体反爬，输出含**明文薪资**的职位数据（JSON / CSV），并生成薪资分布、技能词频和求职材料优化提示词。同时作为 Hermes Agent Skill 提供。
 
 > 📌 **一句话介绍**：不用 Selenium/Playwright，直接通过 Chrome DevTools Protocol 连接本地已登录的 Chrome，复用真实登录态调搜索 API，输出含明文薪资的 JSON/CSV，并生成薪资分布、技能词频和求职材料优化提示词。
 
@@ -45,6 +47,15 @@ python3 scripts/job_summary.py
 - 一键环境检查 + 持久隔离 Chrome CDP profile
 - 多维筛选（规模、融资、薪资、经验、学历、行业）
 - macOS + Linux 支持（Windows 代码分支已预留，未经实测，不保证可用）
+
+<details>
+<summary>🔍 为什么不选 Selenium / Playwright 类爬虫？</summary>
+
+- Selenium/Playwright 会启动完整的受控浏览器，体积大、指纹明显，容易触发 BOSS 的风控和验证码。
+- 本工具直接连接你已经登录的真实 Chrome（CDP），复用真实指纹和登录态，调用的也是页面内合法的搜索 API，返回的 `salaryDesc` 本就是明文——不需要解析被字体反爬加密的 DOM 薪资。
+- 因此比传统 DOM 抓取类爬虫更稳定，也更难被识别为自动化流量。
+
+</details>
 
 ## 安装
 
@@ -192,6 +203,8 @@ boss-zhipin-scraper/
 ```
 
 ## 工作原理
+
+这是一个基于 Chrome CDP 的 BOSS直聘爬虫，核心流程：
 
 1. 通过 Chrome DevTools Protocol (CDP) 连接到已打开的 Chrome
 2. 在 BOSS直聘页面内注入 JS，用同步 XHR 调用搜索 API


### PR DESCRIPTION
## 背景

搜索「boss直聘 爬虫」时，本仓库未出现在 GitHub 搜索前列，而被年久失修的 jhcoco/bosszp 等仓库压在后面。

根因：**关键词匹配度低** —— 仓库文本通篇用「抓取/采集」「zhipin(拼音)」，而用户高频搜索词是「爬虫」「Boss直聘」。GitHub 全文搜索不做中英/同义词转换，导致命中度差。

## 改动

- **中文 README**：标题、首段、特性、工作原理段自然融入「爬虫 / crawler / spider」等高频搜索词（不堆砌，保持可读）
- **新增 README.en.md**：完整英文版，覆盖英文搜索流量（boss zhipin scraper / crawler / spider），与中文版结构一致
- **双语交叉链接**：两份 README 顶部互相链接，便于搜索引擎抓取关联

## 不在本次范围（需手动在网页端设置）

以下两项权重最高，但无法通过代码 PR 修改，需在仓库 About 面板手动设置：

- **Description**：建议填 `Boss直聘爬虫 / BOSS Zhipin job scraper (Chrome CDP, plaintext salary)`
- **Topics**：建议加 `boss-zhipin` `boss直聘` `爬虫` `scraper` `crawler` `spider` `chrome-cdp`

## 验证

- [x] 中文 README 关键词密度自然合理
- [x] 英文版内容与中文版一一对应，无遗漏章节
- [x] 双向链接正确