### PR TITLE
fix: 详情页后台加载标签页，避免抢占前台焦点弹窗

### DIFF
--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -1091,8 +1091,9 @@ def scrape_details(list_data, max_details=None, output_path=None,
         incr_request()
 
         # 每个详情页用新 session 避免检测
+        # background=True：后台创建标签页，不抢占前台焦点，避免抓取时反复弹窗
         ws = CDPSession(cdp_port)
-        r = ws.send("Target.createTarget", {"url": "about:blank"})
+        r = ws.send("Target.createTarget", {"url": "about:blank", "background": True})
         tid = r["result"]["targetId"]
         r = ws.send("Target.attachToTarget", {"targetId": tid, "flatten": True})
         sid = r["result"]["sessionId"]


### PR DESCRIPTION
## 背景

Closes #11

抓取详情页时，`scrape_details` 用 `Target.createTarget` 新建标签页。默认 `background: false`，新 tab 会激活到前台，导致抓取过程中 Chrome 反复弹窗、打断用户。

## 改动

`scripts/boss_cdp_raw.py` `scrape_details` 内，给 `Target.createTarget` 传 `background: true`，让详情页在后台加载：

```diff
-        r = ws.send("Target.createTarget", {"url": "about:blank"})
+        r = ws.send("Target.createTarget", {"url": "about:blank", "background": True})
```

## 为什么安全

- `background` 只控制新 tab 是否激活到前台，**不影响页面加载、JS 执行、`eval_js` 提取 JD**
- 后续的滚动模拟、`Input.dispatchMouseEvent`、`Page.navigate` 都照常工作
- 行为更接近「人类后台浏览」，前台不抢焦点，对风控更自然

## 验证

- [x] `python3 -m py_compile scripts/boss_cdp_raw.py` 通过
- [x] `pytest tests/` 全过（43 passed）
- [x] diff 仅一行改动 + 一行注释

## 待真实验证（合并前/后均可，需本地登录态）

- [ ] 详情 JD 字段、字数与改前一致
- [ ] 抓取过程中 Chrome 不再抢占前台

/cc 