### PR TITLE
fix: 详情页后台标签页注入可见性反检测，修复抓取为空 (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ python3 scripts/boss_cdp_raw.py --setup-chrome --copy-login-state
 python3 scripts/boss_cdp_raw.py --setup-chrome --reset-chrome-profile
 ```
 
+## 📌 TODO
+
+- [ ] 详情页抓取补强 Referer 与请求指纹，进一步降低风控触发概率
+
 ## License
 
 MIT

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -1098,6 +1098,18 @@ def scrape_details(list_data, max_details=None, output_path=None,
         r = ws.send("Target.attachToTarget", {"targetId": tid, "flatten": True})
         sid = r["result"]["sessionId"]
 
+        # background 标签页 document.hidden=true、visibilityState=hidden，
+        # BOSS直聘据此判定为非真人浏览而拒绝渲染/重定向到登录页。
+        # 在导航前注入，覆盖可见性属性为 visible，骗过 visibility 反爬。
+        ws.send("Page.addScriptToEvaluateOnNewDocument", {
+            "source": (
+                "Object.defineProperty(document, 'hidden', {get: () => false});"
+                "Object.defineProperty(document, 'visibilityState', {get: () => 'visible'});"
+                "Object.defineProperty(document, 'webkitHidden', {get: () => false});"
+                "Object.defineProperty(document, 'webkitVisibilityState', {get: () => 'visible'});"
+            )
+        }, sid)
+
         detail_url = build_detail_url(job)
         ws.send("Page.navigate", {"url": detail_url}, sid)
         print(f"  加载页面...")


### PR DESCRIPTION
## 问题

Closes #18

列表页抓取正常，但**详情页几乎全部失败**（列表 90 条 → 详情仅 3 条）。

## 根因

`73a9fff` 将详情页标签页改为 `background: true` 后台加载后，新标签页的 `document.hidden = true`、`visibilityState = "hidden"`，触发 BOSS直聘的 visibility 反爬，被判定为非真人浏览 → 拒绝渲染 / 重定向到登录页，表现为「详情抓不到」。

> 注：issue 作者猜测是 cookie 未继承，实际同 Chrome 实例的默认 browser context 下新 target 本就共享 cookies，并非 cookie 问题。

## 修复

保留 `background: true`（不抢前台焦点、避免 #11 弹窗），在 `Page.navigate` 前通过 `Page.addScriptToEvaluateOnNewDocument` 注入脚本，覆盖可见性属性为 visible：

```js
Object.defineProperty(document, 'hidden', {get: () => false});
Object.defineProperty(document, 'visibilityState', {get: () => 'visible'});
// + webkit 前缀
```

用 getter 而非静态值，应对页面轮询检测；用 `addScriptToEvaluateOnNewDocument` 在页面 JS 执行前注入。

## 测试

本地 `--keyword "HR" --city 上海 --pages 3` 跑通，详情抓取数量恢复正常。

## 后续

详情页 Referer / 请求指纹补强已记入 README TODO。