### PR TITLE
feat: 新增 --stop-chrome / --close-chrome 收尾专用 CDP Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 未发布
 
 ### 新增
+- 新增 `--stop-chrome` 命令：抓取/分析完成后关闭 BOSS 专用 CDP Chrome（按 user-data-dir 精准匹配隔离 profile，不碰主 Chrome）；抓取命令新增 `--close-chrome` 选项，正常结束后自动收尾（默认关闭，异常退出不触发以保留登录态）。复用已有 `stop_cdp_chrome` 的安全匹配逻辑，补齐进程关闭/收尾链路的单元测试。（#26）
 - 城市码表外置为 `data/city_codes.json`（全量 300+ 城市，覆盖一二三四五线），新增 `--list-cities [关键词]` 命令查看支持的城市；`resolve_city` 查询链改为「本地静态码表 → 运行时拉 BOSS 接口 → 原样兜底」。城市码表打进 wheel，`pip install` 用户也可用。（#24）
 
 ### 修复

--- a/README.en.md
+++ b/README.en.md
@@ -1,11 +1,11 @@
-# BOSS Zhipin Scraper · Job Crawler v2.0 (Chrome CDP / Plaintext Salary)
+# BOSS Zhipin Scraper · Job Crawler v2.1 (Chrome CDP / Plaintext Salary)
 
 > 🌐 中文文档：[README.md](./README.md)
 
 ![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)
-![Version](https://img.shields.io/badge/version-2.0.0-orange.svg)
+![Version](https://img.shields.io/badge/version-2.1.0-orange.svg)
 
 A lightweight **BOSS Zhipin scraper / crawler** (a.k.a. spider) for job listings on [zhipin.com](https://www.zhipin.com). Instead of driving a heavy Selenium/Playwright browser, it connects to your **already-logged-in Chrome** via the Chrome DevTools Protocol (CDP), reuses the real session, and calls the in-page search API directly — bypassing the front-end font-based anti-scraping so you get the **plaintext salary** in every record. Output goes to JSON / CSV, plus an aggregated salary/skill analysis and a copy-paste prompt for polishing your job-application materials. Also ships as a Hermes Agent Skill.
 
@@ -164,6 +164,8 @@ python3 scripts/job_summary.py --top 15
 | `--reset-chrome-profile` | Rebuild the dedicated BOSS Chrome profile; clears the login state inside this dedicated browser |
 | `--no-wait-login` | With `--setup-chrome`, do not wait for login to finish |
 | `--login-timeout` | Seconds to wait for login under `--setup-chrome` (default 300) |
+| `--stop-chrome` | Close the dedicated BOSS CDP Chrome (matched precisely by the isolated profile; never touches your main Chrome) |
+| `--close-chrome` | Auto-close the dedicated Chrome after a scrape finishes normally (off by default; not triggered on errors, so the login state is kept) |
 | `--output` | List output path (default `~/.boss-zhipin-scraper/job-result/`) |
 | `--detail-output` | Detail output path (default `~/.boss-zhipin-scraper/job-result/`) |
 | `--cdp-port` | CDP port (default 9222) |
@@ -250,6 +252,24 @@ python3 scripts/boss_cdp_raw.py --setup-chrome --copy-login-state
 ```bash
 python3 scripts/boss_cdp_raw.py --setup-chrome --reset-chrome-profile
 ```
+
+### Tearing down when you're done
+
+After a scrape/analysis finishes, the dedicated Chrome is **not** closed automatically (the login state is kept by default so you can run the next scrape right away). When you're sure you no longer need it, tear it down manually:
+
+```bash
+python3 scripts/boss_cdp_raw.py --stop-chrome
+```
+
+`--stop-chrome` only closes the Chrome process(es) that belong to the scraper's isolated profile (`--user-data-dir`). It **never** kills by port or process name, so it cannot accidentally take down your main Chrome, Gmail, GitHub, or other signed-in sessions.
+
+If you'd rather have a particular scrape close the dedicated Chrome once it finishes normally, add `--close-chrome`:
+
+```bash
+python3 scripts/boss_cdp_raw.py --keyword "AI Agent" --city 上海 --pages 3 --close-chrome
+```
+
+`--close-chrome` is off by default, and it only fires on the **success path** of a completed scrape — login failures, crashes, and other early exits leave the Chrome running so the login state is preserved.
 
 ## 📌 TODO
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# BOSS直聘爬虫 · 职位抓取工具 v2.0（Chrome CDP / 明文薪资）
+# BOSS直聘爬虫 · 职位抓取工具 v2.1（Chrome CDP / 明文薪资）
 
 > 🌐 English documentation: [README.en.md](./README.en.md)
 
 ![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)
-![Version](https://img.shields.io/badge/version-2.0.0-orange.svg)
+![Version](https://img.shields.io/badge/version-2.1.0-orange.svg)
 
 一个轻量的 **BOSS直聘爬虫（spider / crawler / scraper）**：通过 Chrome DevTools Protocol 连接本地已登录的 Chrome，复用真实登录态调用 zhipin.com 搜索 API，绕过前端字体反爬，输出含**明文薪资**的职位数据（JSON / CSV），并生成薪资分布、技能词频和求职材料优化提示词。同时作为 Hermes Agent Skill 提供。
 
@@ -166,6 +166,8 @@ python3 scripts/job_summary.py --top 15
 | `--reset-chrome-profile` | 重建 BOSS 专用 Chrome profile，会清除此专用浏览器内的登录态 |
 | `--no-wait-login` | `--setup-chrome` 启动后不等待登录完成 |
 | `--login-timeout` | `--setup-chrome` 等待登录完成的秒数（默认 300） |
+| `--stop-chrome` | 关闭 BOSS 专用 CDP Chrome（按隔离 profile 精准匹配，不碰主 Chrome） |
+| `--close-chrome` | 抓取正常结束后自动关闭专用 Chrome（默认不关；异常退出不触发，保留登录态） |
 | `--output` | 列表输出路径（默认 `~/.boss-zhipin-scraper/job-result/`） |
 | `--detail-output` | 详情输出路径（默认 `~/.boss-zhipin-scraper/job-result/`） |
 | `--cdp-port` | CDP 端口（默认 9222） |
@@ -251,6 +253,24 @@ python3 scripts/boss_cdp_raw.py --setup-chrome --copy-login-state
 ```bash
 python3 scripts/boss_cdp_raw.py --setup-chrome --reset-chrome-profile
 ```
+
+### 用完如何收尾
+
+抓取/分析结束后，专用 Chrome 不会自动关闭（默认保留登录态，方便你接着跑下一条抓取）。确认不再使用时，可以手动收尾：
+
+```bash
+python3 scripts/boss_cdp_raw.py --stop-chrome
+```
+
+`--stop-chrome` 只关闭 scraper 隔离 profile（`--user-data-dir`）对应的 Chrome 进程，**绝不**按端口或进程名去 kill，因此不会误伤你正在用的主 Chrome、Gmail、GitHub 等账号。
+
+如果你希望某次抓取正常结束后就顺手关掉 Chrome，可以加 `--close-chrome`：
+
+```bash
+python3 scripts/boss_cdp_raw.py --keyword "AI Agent" --city 上海 --pages 3 --close-chrome
+```
+
+`--close-chrome` 默认不开启；且只在抓取走完的**成功路径**上触发，登录失败、异常退出等情况不会关闭 Chrome，登录态得以保留。
 
 ## 📌 TODO
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: boss-zhipin-scraper
 description: "Scrape BOSS直聘 (job listing site) via Chrome CDP. Searches jobs by keyword/city/filters, fetches JD details, outputs structured JSON/CSV with plaintext salary, and can summarize scraped results into a job-market prompt. Use when user wants to search/analyze jobs on BOSS直聘 or zhipin.com."
-version: 2.0.0
+version: 2.1.0
 author: eatmoreduck
 license: MIT
 platforms: [macos, linux]
@@ -10,7 +10,7 @@ metadata:
     tags: [scraper, jobs, career, cdp, chrome, zhipin, boss直聘]
 ---
 
-# BOSS直聘职位抓取工具 v2.0
+# BOSS直聘职位抓取工具 v2.1
 
 通过 Chrome CDP 协议抓取 BOSS直聘 (zhipin.com) 职位数据，输出结构化 JSON/CSV（含明文薪资），并可对已抓取结果生成聚合摘要和求职材料优化提示词。
 
@@ -121,6 +121,18 @@ python3 "$SCRIPT_PATH" --keyword "关键词" --city 北京 --pages 3 --merge ~/.
 
 默认输出到 `~/.boss-zhipin-scraper/job-result/` 目录，`--format csv` 会给列表和详情都额外生成 `.csv` 文件。`--smoke-test` 只验证真实 Chrome/CDP 能否拿到 API 明文薪资，不写结果文件。
 
+抓取结束后专用 Chrome 不会自动关闭（默认保留登录态，方便连跑多条）。确认不再使用时收尾：
+
+```bash
+# 关闭 BOSS 专用 Chrome（只关隔离 profile，不碰主 Chrome）
+python3 "$SCRIPT_PATH" --stop-chrome --cdp-port 9222
+
+# 或：让本次抓取正常结束就自动关闭
+python3 "$SCRIPT_PATH" --keyword "关键词" --city 城市 --pages 3 --close-chrome
+```
+
+`--stop-chrome` 按 `--user-data-dir` 精准匹配，绝不按端口/进程名 kill，因此不会误伤用户主 Chrome。`--close-chrome` 默认关闭，且只在抓取成功路径触发，异常/登录失败不关闭以保留登录态。
+
 摘要脚本只读取 `boss_jobs_*.json` 和 `boss_details_*.json`，不读取本地简历文件，不引入 PDF 依赖，也不给个人与岗位做分数判断。需要指定文件时使用：
 
 ```bash
@@ -152,6 +164,8 @@ python3 "$SUMMARY_PATH" \
 | `--reset-chrome-profile` | 关闭 | 重建 BOSS 专用 profile，会清除此专用浏览器登录态 |
 | `--no-wait-login` | 关闭 | `--setup-chrome` 启动后不等待 BOSS 登录完成 |
 | `--login-timeout` | 300 | `--setup-chrome` 等待登录完成的秒数 |
+| `--stop-chrome` | 关闭 | 关闭 BOSS 专用 CDP Chrome（按隔离 profile 精准匹配，不碰主 Chrome） |
+| `--close-chrome` | 关闭 | 抓取正常结束后自动关闭专用 Chrome（默认不关；异常退出不触发，保留登录态） |
 | `--check` | 关闭 | 环境检查 |
 | `--smoke-test` | 关闭 | 真实 Chrome/CDP 搜索 API smoke test，不写结果文件 |
 | `--version` | - | 查看版本号 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boss-zhipin-scraper"
-version = "2.0.0"
+version = "2.1.0"
 description = "BOSS直聘职位抓取工具 — Chrome CDP + API 明文薪资"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -19,7 +19,7 @@ BOSS直聘职位抓取 + 分析 — 纯 CDP raw protocol
   uv run python3 scripts/boss_cdp_raw.py --version
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 import json
 import time
@@ -1991,6 +1991,32 @@ def run_setup_chrome(cdp_port=DEFAULT_CDP_PORT, copy_login_state=False,
     print(f"示例:")
     print(f"  uv run python3 scripts/boss_cdp_raw.py --keyword \"AI Agent\" --city 上海 --pages 3")
     print(f"  uv run python3 scripts/boss_cdp_raw.py --check")
+    print(f"  uv run python3 scripts/boss_cdp_raw.py --stop-chrome   # 抓完关闭专用 Chrome")
+    print()
+    return 0
+
+
+def run_stop_chrome():
+    """关闭 BOSS 专用 CDP Chrome（按隔离 user-data-dir 精准匹配，不碰主 Chrome）。"""
+    if not require_runtime_dependencies("requests"):
+        return 1
+
+    print("=" * 50)
+    print("  关闭 BOSS 专用 CDP Chrome")
+    print("=" * 50)
+    print()
+
+    # 只定位 scraper 专用 profile 目录，不复制、不重置
+    profile = prepare_cdp_profile(copy_login_state=False, reset=False)
+    cdp_data_dir = profile["path"]
+
+    stopped = stop_cdp_chrome(cdp_data_dir)
+    if stopped:
+        print(f"\n✅ 已关闭 {stopped} 个 BOSS 专用 Chrome 进程 (profile: {cdp_data_dir})")
+    else:
+        print(f"\nℹ️  没有找到运行中的 BOSS 专用 Chrome 进程 (profile: {cdp_data_dir})")
+    print()
+    print("提示：仅关闭 scraper 隔离 profile 的 Chrome，不影响你的主 Chrome。")
     print()
     return 0
 
@@ -2089,6 +2115,10 @@ def main():
                    help="--setup-chrome 启动后不等待 BOSS 登录完成")
     p.add_argument("--login-timeout", type=int, default=DEFAULT_LOGIN_TIMEOUT,
                    help=f"--setup-chrome 等待登录完成的秒数 (默认 {DEFAULT_LOGIN_TIMEOUT})")
+    p.add_argument("--stop-chrome", action="store_true",
+                   help="关闭 BOSS 专用 CDP Chrome（按隔离 profile 精准匹配，不影响主 Chrome）")
+    p.add_argument("--close-chrome", action="store_true",
+                   help="抓取正常结束后自动关闭专用 Chrome（默认不关；异常退出不触发，保留登录态）")
 
     args = p.parse_args()
 
@@ -2113,6 +2143,10 @@ def main():
             wait_login=not args.no_wait_login,
             login_timeout=args.login_timeout,
         ))
+
+    # --stop-chrome 模式（关闭 BOSS 专用 CDP Chrome，独立命令）
+    if args.stop_chrome:
+        sys.exit(run_stop_chrome())
 
     if not require_runtime_dependencies("requests", "websocket"):
         sys.exit(1)
@@ -2196,6 +2230,15 @@ def main():
         if not details:
             details = load_existing_details(args.input, args.detail_output)
         analyze(list_data, details, search_keyword=args.keyword)
+
+    # 抓取正常结束后按需收尾（仅成功路径；异常/登录失败走 sys.exit，不会触发，保留登录态）
+    if args.close_chrome:
+        profile = prepare_cdp_profile(copy_login_state=False, reset=False)
+        stopped = stop_cdp_chrome(profile["path"])
+        if stopped:
+            print(f"\n🧹 已按 --close-chrome 关闭 BOSS 专用 Chrome 进程：{stopped} 个")
+        else:
+            print(f"\nℹ️  --close-chrome 未发现运行中的 BOSS 专用 Chrome 进程")
 
 
 if __name__ == "__main__":

--- a/tests/test_chrome_setup.py
+++ b/tests/test_chrome_setup.py
@@ -692,6 +692,90 @@ class ChromeSetupTests(unittest.TestCase):
                 self.assertEqual(module.chrome_user_data_dirs_for_cdp_port(9333), [str(paths["cdp_profile"])])
                 self.assertTrue(module.cdp_port_uses_profile(9333, str(paths["cdp_profile"])))
 
+    def test_stop_cdp_chrome_terminates_only_matching_profile(self):
+        module = load_module()
+
+        terminated = []
+        # chrome_pids_for_user_data_dir 第一次返回 scraper profile 的 pid（111），
+        # SIGTERM 后轮询返回空 -> 成功关闭，不升级 SIGKILL。
+        # （按 user-data-dir 过滤出 111、不关其它 profile 的进程，该过滤逻辑由
+        #   test_chrome_process_parsing_matches_unquoted_user_data_dir 独立覆盖）
+        pid_lookups = iter([[111], []])
+        with mock.patch.object(module, "chrome_pids_for_user_data_dir",
+                               side_effect=lambda _dir: next(pid_lookups)), \
+             mock.patch.object(module, "terminate_process",
+                               side_effect=lambda pid, force=False: terminated.append((pid, force))), \
+             mock.patch.object(module.time, "sleep"):
+            stopped = module.stop_cdp_chrome("/fake/scraper-profile")
+
+        self.assertEqual(stopped, 1)
+        # 只对 scraper 的 pid 用 SIGTERM（force=False），且只一次
+        self.assertEqual(terminated, [(111, False)])
+
+    def test_stop_cdp_chrome_no_processes_returns_zero(self):
+        module = load_module()
+
+        with mock.patch.object(module, "chrome_pids_for_user_data_dir", return_value=[]):
+            stopped = module.stop_cdp_chrome("/fake/scraper-profile")
+        self.assertEqual(stopped, 0)
+
+    def test_stop_cdp_chrome_escalates_to_force_kill(self):
+        module = load_module()
+
+        terminated = []
+        # SIGTERM 后进程始终在 -> 轮询 10 次都不为空 -> 升级 SIGKILL
+        with mock.patch.object(module, "chrome_pids_for_user_data_dir", return_value=[333]), \
+             mock.patch.object(module, "terminate_process",
+                               side_effect=lambda pid, force=False: terminated.append((pid, force))), \
+             mock.patch.object(module.time, "sleep"):
+            stopped = module.stop_cdp_chrome("/fake/scraper-profile")
+
+        self.assertEqual(stopped, 1)
+        # 先 SIGTERM（force=False），10 次轮询后升级 SIGKILL（force=True）
+        self.assertIn((333, False), terminated)
+        self.assertIn((333, True), terminated)
+        self.assertLess(terminated.index((333, False)), terminated.index((333, True)))
+
+    def test_run_stop_chrome_closes_dedicated_profile(self):
+        module = load_module()
+
+        with tempfile_profile() as paths:
+            scraper_dir = str(paths["cdp_profile"])
+            captured = {}
+
+            def fake_prepare(**kwargs):
+                # run_stop_chrome 必须以 copy_login_state=False, reset=False 调用（只定位，不动 profile）
+                captured["prepare_kwargs"] = kwargs
+                return {"path": scraper_dir, "copied": 0, "reset": False, "copy_login_state": False}
+
+            def fake_stop(directory):
+                captured["stopped_dir"] = directory
+                return 1
+
+            with mock.patch.object(module, "require_runtime_dependencies", return_value=True), \
+                 mock.patch.object(module, "prepare_cdp_profile", side_effect=fake_prepare), \
+                 mock.patch.object(module, "stop_cdp_chrome", side_effect=fake_stop):
+                rc = module.run_stop_chrome()
+
+            self.assertEqual(rc, 0)
+            # 只定位 profile，绝不复制登录态 / 重置
+            self.assertEqual(captured["prepare_kwargs"], {"copy_login_state": False, "reset": False})
+            # 关的就是 scraper 隔离 profile 目录
+            self.assertEqual(captured["stopped_dir"], scraper_dir)
+
+    def test_run_stop_chrome_returns_zero_when_no_chrome_running(self):
+        module = load_module()
+
+        with tempfile_profile() as paths:
+            scraper_dir = str(paths["cdp_profile"])
+            with mock.patch.object(module, "require_runtime_dependencies", return_value=True), \
+                 mock.patch.object(module, "prepare_cdp_profile",
+                                   return_value={"path": scraper_dir, "copied": 0,
+                                                 "reset": False, "copy_login_state": False}), \
+                 mock.patch.object(module, "stop_cdp_chrome", return_value=0):
+                rc = module.run_stop_chrome()
+            self.assertEqual(rc, 0)
+
     def test_help_does_not_require_cdp_runtime_dependencies(self):
         result = subprocess.run(
             [sys.executable, str(SCRIPT_PATH), "--help"],
@@ -705,6 +789,8 @@ class ChromeSetupTests(unittest.TestCase):
         self.assertIn("--reset-chrome-profile", result.stdout)
         self.assertIn("--no-wait-login", result.stdout)
         self.assertIn("--login-timeout", result.stdout)
+        self.assertIn("--stop-chrome", result.stdout)
+        self.assertIn("--close-chrome", result.stdout)
 
 
 class tempfile_profile:


### PR DESCRIPTION
## 改了什么

修复 #26：`--setup-chrome` 启动的调试 Chrome（独立 profile，端口 9222）在抓取/分析流程结束后不会自动关闭，进程一直驻留，需要用户手动去关。

按讨论结论「**默认不关，提供显式收尾入口**」，新增两个选项（均默认不开启）：

- **`--stop-chrome`**（独立命令）：关闭 BOSS 专用 CDP Chrome。复用已有的 `stop_cdp_chrome`，按 `--user-data-dir` 精准匹配 scraper 隔离 profile，**绝不**按端口/进程名 kill，不会误伤用户主 Chrome。
- **`--close-chrome`**（抓取选项）：抓取正常结束后自动关闭专用 Chrome。仅在抓取**成功路径**触发——登录失败、异常退出等情况不触发，保留登录态。
- 顺带在 `--setup-chrome` 完成后的示例命令里加了 `--stop-chrome` 提示。

## 为什么改

关闭能力（`stop_cdp_chrome` → `chrome_pids_for_user_data_dir`）其实早就实现了，但只用在 `--setup-chrome` 启动前清理旧进程，从未暴露到抓取流程。本次只是把这条安全链路接到 CLI 上，没有新写任何进程遍历逻辑。

默认不关的理由：setup 和 scrape 是两个独立终端会话，Chrome 跨会话存活是必需的（一次登录 → 连跑多条抓取）；且代码注释明确「异常退出保留数据/登录态」，默认杀 Chrome 会破坏这个设计。

## 怎么测的

补了 6 个单元测试（`stop_cdp_chrome` / `terminate_process` / `run_stop_chrome` 此前**零覆盖**）：

- `test_stop_cdp_chrome_terminates_only_matching_profile` — SIGTERM 只关匹配 profile 的 pid，单次不升级
- `test_stop_cdp_chrome_no_processes_returns_zero` — 无进程返回 0
- `test_stop_cdp_chrome_escalates_to_force_kill` — SIGTERM 后进程仍在，轮询后升级 SIGKILL
- `test_run_stop_chrome_closes_dedicated_profile` — 验证用 `copy_login_state=False, reset=False` 调 `prepare_cdp_profile`（只定位不动 profile），且关的是 scraper 目录
- `test_run_stop_chrome_returns_zero_when_no_chrome_running` — 无实例时返回 0
- `test_help_does_not_require_cdp_runtime_dependencies` — 补充 `--stop-chrome` / `--close-chrome` 出现在 `--help`

```
python3 -m py_compile scripts/boss_cdp_raw.py   ✅
python3 -m unittest tests.test_chrome_setup     ✅ Ran 53 tests, OK
```

## 其它

- 版本号 `2.0.0 → 2.1.0`（新增 CLI 命令算 feature），四处同步：脚本 `__version__`、`pyproject.toml`、`SKILL.md`、`README.md`，并同步 `README.en.md`（双语一致）
- `CHANGELOG.md` 在 `## 未发布 / ### 新增` 下加了一条
- 文档同步：`README.md` / `README.en.md`（参数表 + 新增「用完如何收尾」章节，中英对称）、`SKILL.md`（参数速查表三列 + 自动化流程示例）

Closes #26