### PR TITLE
fix: keep automation targets in background (#28)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ SKILL.md / README(.en).md / CHANGELOG.md / CONTRIBUTING.md
 
 - `scripts/boss_cdp_raw.py` 是一个**长单文件**，包含：`CDPSession` 类（WebSocket 连 CDP）、各种 `EXTRACT_*_JS` 注入脚本、`scrape_jobs`（列表走 `/wapi/...` API）、`scrape_details`（详情走新开 tab 渲染）、`main`（argparse）。城市码表外置到 `data/city_codes.json`，`resolve_city` 查询链为「本地静态码表 → 运行时拉 BOSS 接口 → 原样兜底」。
 - **列表页 vs 详情页路径完全不同**：列表页通过页面内 `fetch` 调 BOSS wapi（带 token，不经页面渲染）；详情页通过 `Target.createTarget` 新开 tab → `Page.navigate` → 注入 JS 提取。改其中一条路径时，另一条不受影响。
-- **CDP `background:true` 的坑（issue #18）**：后台 tab 的 `document.hidden=true` 会触发 BOSS visibility 反爬，导致详情抓空。当前在 `scrape_details` 导航前用 `Page.addScriptToEvaluateOnNewDocument` 注入脚本覆盖可见性属性为 visible。动详情页逻辑时别破坏这段。
+- **CDP target 焦点/可见性不变量**：统一通过 `create_page_session` 创建页面；自动化 target 默认后台打开并在导航前注册 visibility override，避免抢焦点且避免 `document.hidden=true` 触发 BOSS visibility 反爬（issue #18）。只有需要用户操作的 `wait_for_login` 显式传 `background=False`。不要绕过 helper 直接新增 `Target.createTarget`。
 - 同一个 Chrome 实例的默认 browser context 下，新开 target **本就共享 cookies**，不要被「新 tab 丢 cookie」的直觉误导。
 - `require_runtime_dependencies("requests", "websocket")` 在多个入口前置检查依赖，缺了会提示安装。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - 城市码表外置为 `data/city_codes.json`（全量 300+ 城市，覆盖一二三四五线），新增 `--list-cities [关键词]` 命令查看支持的城市；`resolve_city` 查询链改为「本地静态码表 → 运行时拉 BOSS 接口 → 原样兜底」。城市码表打进 wheel，`pip install` 用户也可用。（#24）
 
 ### 修复
+- 登录检查、列表/详情抓取和 smoke test 的临时标签页统一在后台创建，仅人工登录页置前，避免自动流程抢占前台焦点（#28）
 - 详情页 JD 改为只提取“职位描述”区，并在登录墙、导航页或过短正文出现时拒绝写入，不再把整页 `body`、招聘者信息、公司介绍和推荐职位当作 JD
 - 同步 BOSS 当前 `city.json` / `condition.json` 映射，修正城市码以及薪资、经验、学历筛选枚举漂移，并在内置城市表未命中时自动加载 BOSS `cityGroup.json` 支持更多城市中文名
 - `scrape_details` 最终保存改用 `os.path.dirname(path) or "."`，`--detail-output` 传不带目录的裸文件名时不再抛 `FileNotFoundError`（与循环内及其它写文件处保持一致）

--- a/README.en.md
+++ b/README.en.md
@@ -239,6 +239,8 @@ Without an explicit `--output` or `--detail-output`, scraping results are saved 
 
 On first use you must log in to BOSS Zhipin manually inside this dedicated Chrome. `--setup-chrome` waits for the login to finish and uses the search API to confirm it can get plaintext `salaryDesc` before returning. The session is stored inside the dedicated profile and survives reboots; re-running `--setup-chrome` does not wipe it and does not affect your main Chrome, Gmail, GitHub, or other accounts.
 
+The interactive login page opened by `--setup-chrome` is the only temporary page intentionally brought to the foreground. Temporary tabs used by environment checks, list/detail scraping, and the smoke test run in the background so automation does not repeatedly steal focus. “Background” here only means the tab is not activated; the dedicated Chrome still runs with a visible UI and can be opened manually for inspection.
+
 If you really need to import the BOSS session from your main Chrome, run explicitly:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ boss-zhipin-scraper/
 
 首次使用需要在这个专用 Chrome 中手动登录 BOSS直聘。`--setup-chrome` 会等待登录完成，并用搜索接口确认能拿到明文 `salaryDesc` 后再返回。登录态保存在专用 profile 内，重启机器后仍然保留；重复运行 `--setup-chrome` 不会清空它，也不会影响主 Chrome、Gmail、GitHub 等账号。
 
+`--setup-chrome` 的交互式登录页是唯一会主动置前的临时页面；环境检查、列表/详情抓取和 smoke test 创建的临时标签页都会在后台运行，避免自动流程反复抢占当前窗口。这里的“后台”仅表示不激活标签页，专用 Chrome 仍以有界面模式运行，必要时可以手动打开检查。
+
 如确实需要从主 Chrome 手动导入 BOSS 登录态，可以显式运行：
 
 ```bash

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -337,6 +337,41 @@ class CDPSession:
         self.ws.close()
 
 
+BACKGROUND_VISIBILITY_SCRIPT = (
+    "Object.defineProperty(document, 'hidden', {get: () => false});"
+    "Object.defineProperty(document, 'visibilityState', {get: () => 'visible'});"
+    "Object.defineProperty(document, 'webkitHidden', {get: () => false});"
+    "Object.defineProperty(document, 'webkitVisibilityState', {get: () => 'visible'});"
+)
+
+
+def create_page_session(cdp, background=True):
+    """Create and attach an about:blank target without stealing focus by default.
+
+    Background pages report themselves as hidden, which prevents BOSS detail
+    pages from rendering reliably. Register the existing visibility override
+    before callers navigate. Interactive callers such as the login flow must
+    opt into a foreground target explicitly.
+    """
+    target = cdp.send(
+        "Target.createTarget",
+        {"url": "about:blank", "background": background},
+    )
+    target_id = target["result"]["targetId"]
+    attached = cdp.send(
+        "Target.attachToTarget",
+        {"targetId": target_id, "flatten": True},
+    )
+    session_id = attached["result"]["sessionId"]
+    if background:
+        cdp.send(
+            "Page.addScriptToEvaluateOnNewDocument",
+            {"source": BACKGROUND_VISIBILITY_SCRIPT},
+            session_id,
+        )
+    return target_id, session_id
+
+
 # ============================================================
 # 通过页面内 XHR 调 API 获取列表数据（明文薪资）
 # ============================================================
@@ -721,10 +756,7 @@ def check_login_state(cdp_port=DEFAULT_CDP_PORT):
     """
     try:
         cdp = CDPSession(cdp_port)
-        r = cdp.send("Target.createTarget", {"url": "about:blank"})
-        tid = r["result"]["targetId"]
-        r = cdp.send("Target.attachToTarget", {"targetId": tid, "flatten": True})
-        sid = r["result"]["sessionId"]
+        tid, sid = create_page_session(cdp)
 
         # 先导航到 BOSS直聘，确保 cookie 域名正确
         cdp.send("Page.navigate", {"url": "https://www.zhipin.com/"}, sid)
@@ -745,10 +777,12 @@ def check_login_state(cdp_port=DEFAULT_CDP_PORT):
 def wait_for_login(cdp_port=DEFAULT_CDP_PORT, timeout=DEFAULT_LOGIN_TIMEOUT, interval=3):
     """Open BOSS login page and wait until plaintext salary is available."""
     cdp = CDPSession(cdp_port)
-    r = cdp.send("Target.createTarget", {"url": "https://www.zhipin.com/web/user/"})
-    tid = r["result"]["targetId"]
-    r = cdp.send("Target.attachToTarget", {"targetId": tid, "flatten": True})
-    sid = r["result"]["sessionId"]
+    tid, sid = create_page_session(cdp, background=False)
+    cdp.send(
+        "Page.navigate",
+        {"url": "https://www.zhipin.com/web/user/"},
+        sid,
+    )
 
     deadline = time.time() + timeout
     logged_in = False
@@ -1090,10 +1124,7 @@ def scrape_list(keyword, city_input, max_pages, filters, output_path,
         print(f"筛选: {' | '.join(filter_desc)}")
     print()
 
-    r = cdp.send("Target.createTarget", {"url": "about:blank"})
-    tid = r["result"]["targetId"]
-    r = cdp.send("Target.attachToTarget", {"targetId": tid, "flatten": True})
-    sid = r["result"]["sessionId"]
+    tid, sid = create_page_session(cdp)
 
     def human_scroll(cdp, sid):
         """模拟人类滚动: 随机次数、随机距离、随机停顿，偶尔回滚一点"""
@@ -1285,25 +1316,9 @@ def scrape_details(list_data, max_details=None, output_path=None,
 
         incr_request()
 
-        # 每个详情页用新 session 避免检测
-        # background=True：后台创建标签页，不抢占前台焦点，避免抓取时反复弹窗
+        # 每个详情页用新 session 避免检测；自动化 target 默认后台创建。
         ws = CDPSession(cdp_port)
-        r = ws.send("Target.createTarget", {"url": "about:blank", "background": True})
-        tid = r["result"]["targetId"]
-        r = ws.send("Target.attachToTarget", {"targetId": tid, "flatten": True})
-        sid = r["result"]["sessionId"]
-
-        # background 标签页 document.hidden=true、visibilityState=hidden，
-        # BOSS直聘据此判定为非真人浏览而拒绝渲染/重定向到登录页。
-        # 在导航前注入，覆盖可见性属性为 visible，骗过 visibility 反爬。
-        ws.send("Page.addScriptToEvaluateOnNewDocument", {
-            "source": (
-                "Object.defineProperty(document, 'hidden', {get: () => false});"
-                "Object.defineProperty(document, 'visibilityState', {get: () => 'visible'});"
-                "Object.defineProperty(document, 'webkitHidden', {get: () => false});"
-                "Object.defineProperty(document, 'webkitVisibilityState', {get: () => 'visible'});"
-            )
-        }, sid)
+        tid, sid = create_page_session(ws)
 
         detail_url = build_detail_url(job)
         ws.send("Page.navigate", {"url": detail_url}, sid)
@@ -1614,12 +1629,10 @@ def run_smoke_test(cdp_port=DEFAULT_CDP_PORT):
         cdp = CDPSession(cdp_port)
         city_name, city_code = resolve_city(DEFAULT_CITY_INPUT)
         search_url = build_search_url(LOGIN_PROBE_QUERY, city_code, 1, {})
-        r = cdp.send("Target.createTarget", {"url": search_url})
-        tid = r["result"]["targetId"]
-        r = cdp.send("Target.attachToTarget", {"targetId": tid, "flatten": True})
-        sid = r["result"]["sessionId"]
+        tid, sid = create_page_session(cdp)
 
         print(f"打开 BOSS 搜索页: {LOGIN_PROBE_QUERY} @ {city_name}")
+        cdp.send("Page.navigate", {"url": search_url}, sid)
         time.sleep(4)
         api_url = f"{API_JOB_LIST_PATH}?{urlencode({'scene': '1', 'query': LOGIN_PROBE_QUERY, 'city': city_code, 'page': 1, 'pageSize': 5})}"
         api_js = FETCH_API_JS_TEMPLATE.replace("__API_URL__", api_url)

--- a/tests/test_chrome_setup.py
+++ b/tests/test_chrome_setup.py
@@ -41,6 +41,100 @@ class ChromeSetupTests(unittest.TestCase):
         self.assertIn("boss_jobs_", module.default_output_path("jobs"))
         self.assertIn("boss_details_", module.default_output_path("details"))
 
+    def test_create_page_session_defaults_to_background_with_visibility_override(self):
+        module = load_module()
+        cdp = mock.Mock()
+        cdp.send.side_effect = [
+            {"result": {"targetId": "target-1"}},
+            {"result": {"sessionId": "session-1"}},
+            {"result": {}},
+        ]
+
+        result = module.create_page_session(cdp)
+
+        self.assertEqual(result, ("target-1", "session-1"))
+        self.assertEqual(
+            cdp.send.call_args_list,
+            [
+                mock.call(
+                    "Target.createTarget",
+                    {"url": "about:blank", "background": True},
+                ),
+                mock.call(
+                    "Target.attachToTarget",
+                    {"targetId": "target-1", "flatten": True},
+                ),
+                mock.call(
+                    "Page.addScriptToEvaluateOnNewDocument",
+                    {"source": module.BACKGROUND_VISIBILITY_SCRIPT},
+                    "session-1",
+                ),
+            ],
+        )
+
+    def test_create_page_session_can_open_interactive_foreground_target(self):
+        module = load_module()
+        cdp = mock.Mock()
+        cdp.send.side_effect = [
+            {"result": {"targetId": "login-target"}},
+            {"result": {"sessionId": "login-session"}},
+        ]
+
+        result = module.create_page_session(
+            cdp,
+            background=False,
+        )
+
+        self.assertEqual(result, ("login-target", "login-session"))
+        self.assertEqual(
+            cdp.send.call_args_list,
+            [
+                mock.call(
+                    "Target.createTarget",
+                    {
+                        "url": "about:blank",
+                        "background": False,
+                    },
+                ),
+                mock.call(
+                    "Target.attachToTarget",
+                    {"targetId": "login-target", "flatten": True},
+                ),
+            ],
+        )
+
+    def test_wait_for_login_explicitly_uses_foreground_target(self):
+        module = load_module()
+        cdp = mock.Mock()
+        with mock.patch.object(module, "CDPSession", return_value=cdp), \
+                mock.patch.object(
+                    module,
+                    "create_page_session",
+                    return_value=("login-target", "login-session"),
+                ) as create_session, \
+                mock.patch.object(module, "probe_login_state", return_value=True):
+            self.assertTrue(module.wait_for_login(cdp_port=9333, timeout=1))
+
+        create_session.assert_called_once_with(
+            cdp,
+            background=False,
+        )
+        self.assertEqual(
+            cdp.send.call_args_list,
+            [
+                mock.call(
+                    "Page.navigate",
+                    {"url": "https://www.zhipin.com/web/user/"},
+                    "login-session",
+                ),
+                mock.call(
+                    "Target.closeTarget",
+                    {"targetId": "login-target"},
+                ),
+            ],
+        )
+        cdp.close.assert_called_once_with()
+
     def test_default_city_is_shanghai_when_not_provided(self):
         module = load_module()
 


### PR DESCRIPTION
## 改了什么

- 新增 `create_page_session`，统一 `Target.createTarget` / `Target.attachToTarget`
- 自动化 target 默认 `background=True`，覆盖登录检查、列表抓取、详情抓取和 `--smoke-test`
- helper 固定先创建 `about:blank`，后台 target 在业务导航前统一注册现有 visibility override，避免重现 #18
- `wait_for_login` 显式使用 `background=False`，`--setup-chrome` 的交互式登录体验保持不变
- 补充 3 个聚焦测试，并同步 `README.md`、`README.en.md`、`CHANGELOG.md` 和 `AGENTS.md`

## 为什么这样改

#11 / #12 只修复了详情页反复抢前台的问题，登录检查、列表抓取和 smoke test 仍直接调用 `Target.createTarget` 的前台默认行为，因此自动流程开始时仍可能弹出 Chrome。

本 PR 把不变量收敛到一个 helper：除人工登录页外，脚本创建的临时页面一律后台打开。CDP 官方文档说明 `background` 决定 target 在后台还是前台创建：

- https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-createTarget

没有采用整窗最小化或负坐标移屏：用户可以通过自定义 CDP 端口连接非专用 Chrome，整窗操作副作用更大；同时 Chromium 将 `--disable-backgrounding-occluded-windows` 明确标记为测试用途，不适合作为正常运行默认值。

## 行为与兼容性

- 自动化临时标签页不再主动抢占前台焦点
- 需要用户操作的登录页仍正常置前
- 保留详情页已经验证过的 visibility 兼容逻辑，并让其他后台 target 复用同一实现
- 不新增 CLI 参数、依赖或 BOSS 网络请求，不改变数据处理逻辑、profile、Cookie 或 Chrome 进程生命周期

## 怎么测的

```text
python3 -m unittest tests.test_chrome_setup tests.test_job_summary
Ran 64 tests ... OK

python3 -m py_compile scripts/boss_cdp_raw.py
exit 0

uv build
Successfully built sdist + wheel

git diff --check
exit 0
```

真实环境验证（macOS、headed Chrome 149、CDP protocol 1.3）：

- `--check`：通过，登录态正常
- `--smoke-test`：通过，拿到明文薪资
- 单页列表抓取：成功返回 30 条职位
- smoke 运行期间每 100ms 采样前台应用，Chrome 未成为 frontmost application

Closes #28
