### PR TITLE
fix: Windows 兼容与数据安全修复（GBK 控制台崩溃 / JSON 原子写盘 / 死代码清理）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - API URL filter 改用 `urlencode`（原字符串拼接，filter 值含特殊字符会出错）
 
 ### 变更
+- 平台支持声明更新：Windows 已通过单元测试与基础 CLI 验证（GBK 控制台崩溃等已修复），README 中英双语同步调整（此前 v2.0.0 撤回的"未经实测"声明在本修复后更新）
 - 平台支持声明改为 macOS + Linux（Windows 代码分支保留但未经实测，不再声称支持，避免过度承诺）
 - `pyproject.toml` 删除空的 `[csv]` extra（csv 是标准库）
 - SKILL.md 脚本路径解析改用 Python `os.path.realpath`（macOS 自带 `readlink` 无 `-f`）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - 城市码表外置为 `data/city_codes.json`（全量 300+ 城市，覆盖一二三四五线），新增 `--list-cities [关键词]` 命令查看支持的城市；`resolve_city` 查询链改为「本地静态码表 → 运行时拉 BOSS 接口 → 9 位裸码兜底」。城市码表打进 wheel，`pip install` 用户也可用。（#24）
 
 ### 修复
+- Windows 兼容：`main()` 入口将 stdout/stderr 重配为 UTF-8，修复 Windows GBK 控制台遇到 emoji（✅❌⚠️ 等）输出直接 `UnicodeEncodeError` 崩溃的问题（实测此前 73 个单测中 8 个因此失败）
+- JSON 落盘改为原子写入（临时文件 + `os.replace`）：进程中断不再留下半截 JSON 覆盖旧数据；`flush_jobs`、详情页写入与 `--merge` 详情落盘统一走 `_atomic_write_json`
+- `--check` 的 CDP 连通检查不再把任意 CDP 服务误报为「Chrome」，改为输出实际服务标识
+- 清理死代码与重复实现：删除无调用方的 `append_json`；`flush_jobs`/`merge_jobs`/`merge_details_from_lists` 的读-去重-写收敛到 `merge_unique`；`parse_jobs_eval_value` 与 `parse_api_jobs_eval_value` 合并（smoke test 改用后者，行为不变）
+- 测试平台适配：Chrome 进程查询的 mock 输出改为按平台生成（Windows 分支解析 PowerShell JSON、POSIX 分支解析 ps 文本），修复 Windows 上 3 个既有测试失败；`test_help_does_not_require_cdp_runtime_dependencies` 显式指定 UTF-8 解码；新增 `merge_unique` / `_atomic_write_json` / `flush_jobs` 单元测试（全量 92 个测试通过）
 - 城市解析先执行本地及在线码表的正反向映射，再接受未收录的 9 位裸城市码；未知城市名现在会在抓取前明确报错退出。在线城市接口同时校验业务 `code`，不再把 `code: 35` 等风控响应静默当作空码表
 - 登录探测识别 BOSS 风控码 `code: 37`「您的环境存在异常」为限制状态（RESTRICTED），并对未知风控码按 message 关键字（环境存在异常、访问频繁、安全校验等）兜底识别；避免已登录但被风控/限流的用户被误判为「登录探测响应异常」而无法继续。（#33）
 - 登录探测改为区分可用、未登录、限制、空结果和响应异常；每轮仅请求一次并采用有上限的退避等待，`code: 31` 等明确限制会立即停止。探测请求现已纳入全局请求预算，CLI 不再把风控或异常统一提示为未登录。（#31）

--- a/README.en.md
+++ b/README.en.md
@@ -54,7 +54,7 @@ Right after scraping you get: salary ranges, experience requirements, top skill 
 - Incremental writes (no data loss on crash)
 - One-shot environment check + persistent isolated Chrome CDP profile
 - Multi-dimension filters (scale, funding, salary, experience, degree, industry)
-- macOS + Linux support (a Windows code path is reserved but untested — not guaranteed to work)
+- macOS + Linux support; Windows is verified by unit tests and basic CLI checks (GBK console crash fixed), real scraping flows still welcome feedback
 
 <details>
 <summary>🔍 Why not a Selenium / Playwright crawler?</summary>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python3 scripts/job_summary.py
 - 增量写入（异常退出不丢数据）
 - 一键环境检查 + 持久隔离 Chrome CDP profile
 - 多维筛选（规模、融资、薪资、经验、学历、行业）
-- macOS + Linux 支持（Windows 代码分支已预留，未经实测，不保证可用）
+- macOS + Linux 支持；Windows 已通过单元测试与基础 CLI 验证（GBK 控制台崩溃已修复），真实抓取链路仍欢迎反馈
 
 <details>
 <summary>🔍 为什么不选 Selenium / Playwright 类爬虫？</summary>

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -1123,53 +1123,67 @@ def write_detail_csv(csv_path, details):
 # ============================================================
 # 增量写入 JSON
 # ============================================================
-def append_json(path, new_jobs):
-    """追加 jobs 到 JSON 文件，每条按 job_id 去重"""
-    existing = []
-    seen_ids = set()
-    data = {}
-    if os.path.exists(path):
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            existing = data.get("jobs", [])
-            seen_ids = {j.get("job_id", "") for j in existing}
-        except (json.JSONDecodeError, OSError, ValueError):
-            data = {}
-    added = 0
-    for j in new_jobs:
-        if j.get("job_id") not in seen_ids:
-            existing.append(j)
-            seen_ids.add(j.get("job_id", ""))
-            added += 1
-    data["jobs"] = existing
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
-    return added
+def merge_unique(existing, incoming, key="job_id", new_overrides=False):
+    """按 key 合并去重。
+
+    Args:
+        existing: 已有记录列表
+        incoming: 新记录列表
+        key: 去重字段
+        new_overrides: True 时新记录覆盖旧记录（同 key 保留新的）；False 时旧记录优先
+
+    Returns:
+        合并后的列表
+    """
+    if new_overrides:
+        by_key = {}
+        for item in existing:
+            if isinstance(item, dict) and item.get(key):
+                by_key[item.get(key)] = item
+        for item in incoming:
+            if isinstance(item, dict) and item.get(key):
+                by_key[item.get(key)] = item
+        return list(by_key.values())
+
+    seen = {item.get(key, "") for item in existing if isinstance(item, dict)}
+    merged = list(existing)
+    for item in incoming:
+        if isinstance(item, dict) and item.get(key, "") not in seen:
+            seen.add(item.get(key, ""))
+            merged.append(item)
+    return merged
+
+
+def _atomic_write_json(path, payload):
+    """先写临时文件再原子替换，避免进程中断留下半截 JSON 覆盖旧数据。"""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp_path = f"{path}.tmp{os.getpid()}"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
 
 
 def flush_jobs(path, meta, jobs):
     """每次有新数据就全量刷写（jobs 去重后），保证异常退出也能保留"""
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    # 合并已有文件
     existing_jobs = []
-    seen_ids = set()
     if os.path.exists(path):
         try:
             with open(path, "r", encoding="utf-8") as f:
                 old = json.load(f)
             existing_jobs = old.get("jobs", [])
-            seen_ids = {j.get("job_id", "") for j in existing_jobs}
         except (json.JSONDecodeError, OSError, ValueError):
             pass
-    for j in jobs:
-        if j.get("job_id") not in seen_ids:
-            existing_jobs.append(j)
-            seen_ids.add(j.get("job_id", ""))
-    meta["total"] = len(existing_jobs)
-    meta["jobs"] = existing_jobs
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(meta, f, ensure_ascii=False, indent=2)
+    merged = merge_unique(existing_jobs, jobs)
+    meta["total"] = len(merged)
+    meta["jobs"] = merged
+    _atomic_write_json(path, meta)
 
 
 # ============================================================
@@ -1193,16 +1207,8 @@ def merge_jobs(external_path, new_jobs):
         return new_jobs
 
     old_jobs = old_data.get("jobs", [])
-    merged = list(old_jobs)
-    seen_ids = {j.get("job_id", "") for j in merged}
-
-    added = 0
-    for j in new_jobs:
-        if j.get("job_id") not in seen_ids:
-            merged.append(j)
-            seen_ids.add(j.get("job_id", ""))
-            added += 1
-
+    merged = merge_unique(old_jobs, new_jobs)
+    added = len(merged) - len(old_jobs)
     print(f"合并: 旧文件 {len(old_jobs)} 条 + 新抓取 {len(new_jobs)} 条 = {len(merged)} 条 (新增 {added})")
     return merged
 
@@ -1243,16 +1249,7 @@ def merge_details(external_path, new_details):
 
 def merge_details_from_lists(old_details, new_details):
     """把两份详情列表按 job_id 合并去重，new_details 优先（同 id 用新覆盖旧）。"""
-    by_id = {}
-    for d in old_details:
-        jid = d.get("job_id", "") if isinstance(d, dict) else ""
-        if jid:
-            by_id[jid] = d
-    for d in new_details:
-        jid = d.get("job_id", "") if isinstance(d, dict) else ""
-        if jid:
-            by_id[jid] = d
-    return list(by_id.values())
+    return merge_unique(old_details, new_details, new_overrides=True)
 
 
 # ============================================================
@@ -1669,9 +1666,7 @@ def scrape_details(list_data, max_details=None, output_path=None,
 
         # 每抓完一个详情就写入，异常退出也能保留
         if output_path:
-            os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-            with open(output_path, "w", encoding="utf-8") as f:
-                json.dump(results, f, ensure_ascii=False, indent=2)
+            _atomic_write_json(output_path, results)
 
         ws.send("Target.closeTarget", {"targetId": tid})
         ws.close()
@@ -1681,9 +1676,7 @@ def scrape_details(list_data, max_details=None, output_path=None,
         time.sleep(gap)
 
     # 最终保存（dirname 为空时回退到当前目录，与循环内/其它写文件处保持一致）
-    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(results, f, ensure_ascii=False, indent=2)
+    _atomic_write_json(output_path, results)
     print(f"\n详情已保存: {output_path}")
 
     if fmt == "csv":
@@ -1885,16 +1878,6 @@ def analyze(list_data, details=None, search_keyword=""):
         print("  提示: 用 --detail 抓取 JD 详情后可获得更精准的简历建议")
 
 
-def parse_jobs_eval_value(value):
-    if not value:
-        return []
-    try:
-        parsed = json.loads(value) if isinstance(value, str) else value
-    except (json.JSONDecodeError, ValueError, TypeError):
-        return []
-    return parsed if isinstance(parsed, list) else []
-
-
 def has_usable_smoke_jobs(jobs):
     for job in jobs:
         if not isinstance(job, dict):
@@ -1925,7 +1908,7 @@ def run_smoke_test(cdp_port=DEFAULT_CDP_PORT):
         time.sleep(4)
         api_url = f"{API_JOB_LIST_PATH}?{urlencode({'scene': '1', 'query': LOGIN_PROBE_QUERY, 'city': city_code, 'page': 1, 'pageSize': 5})}"
         api_js = FETCH_API_JS_TEMPLATE.replace("__API_URL__", api_url)
-        jobs = parse_jobs_eval_value(cdp.eval_js(api_js, sid))
+        jobs = parse_api_jobs_eval_value(cdp.eval_js(api_js, sid))
         cdp.send("Target.closeTarget", {"targetId": tid})
         cdp.close()
 
@@ -1975,7 +1958,7 @@ def run_check(cdp_port=DEFAULT_CDP_PORT):
             resp = requests.get(f"http://127.0.0.1:{cdp_port}/json/version", timeout=5)
             data = resp.json()
             browser = data.get("Browser", "未知")
-            print(f"  ✅ 通过 — Chrome {browser}")
+            print(f"  ✅ 通过 — CDP 服务: {browser}")
         except (requests.ConnectionError, requests.Timeout):
             print(f"  ❌ 失败 — 无法连接 127.0.0.1:{cdp_port}")
             print(f"     请先启动 Chrome CDP: python3 {__file__} --setup-chrome")
@@ -2330,6 +2313,11 @@ def run_stop_chrome():
 # main
 # ============================================================
 def main():
+    # Windows 控制台默认 GBK 无法编码输出中的 emoji/部分中文，会直接 UnicodeEncodeError
+    # （实测 73 个单测中 8 个因此失败）。统一重配为 UTF-8，输出用 errors=replace 兜底。
+    for stream in (sys.stdout, sys.stderr):
+        if stream is not None and hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
     p = argparse.ArgumentParser(
         description=f"BOSS直聘抓取 + 分析 (CDP Raw) v{__version__}",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -2540,9 +2528,7 @@ def main():
         # 若处于合并流程，把旧详情并入本次抓取结果并重新落盘，保证 --merge 后详情不丢失
         if merged_details and args.detail_output:
             details = merge_details_from_lists(merged_details, details)
-            os.makedirs(os.path.dirname(args.detail_output) or ".", exist_ok=True)
-            with open(args.detail_output, "w", encoding="utf-8") as f:
-                json.dump(details, f, ensure_ascii=False, indent=2)
+            _atomic_write_json(args.detail_output, details)
             print(f"合并详情已保存: {args.detail_output}")
             if args.format == "csv":
                 detail_csv = args.detail_output.rsplit(".", 1)[0] + ".csv"

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -1161,6 +1161,9 @@ def _atomic_write_json(path, payload):
     try:
         with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
+            # 落盘前刷出并 fsync，极端断电场景下数据不丢（review 建议）
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp_path, path)
     finally:
         if os.path.exists(tmp_path):

--- a/scripts/job_summary.py
+++ b/scripts/job_summary.py
@@ -361,6 +361,10 @@ def positive_int(raw):
 
 
 def main(argv=None):
+    # 与 boss_cdp_raw.py 保持一致：Windows GBK 控制台重配 UTF-8，避免 emoji 输出崩溃。
+    for stream in (sys.stdout, sys.stderr):
+        if stream is not None and hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
     parser = build_arg_parser()
     args = parser.parse_args(argv)
 

--- a/tests/test_chrome_setup.py
+++ b/tests/test_chrome_setup.py
@@ -4,12 +4,20 @@ import io
 import json
 import os
 import pathlib
+import platform
 import re
 import subprocess
 import sys
 import unittest
 from contextlib import redirect_stdout
 from unittest import mock
+
+
+# Windows 控制台默认 GBK，测试断言/回溯含 emoji 会 UnicodeEncodeError；
+# 统一重配为 UTF-8，保证测试不依赖外部 PYTHONIOENCODING 环境变量。
+for _stream in (sys.stdout, sys.stderr):
+    if _stream is not None and hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
 
 
 SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "boss_cdp_raw.py"
@@ -528,6 +536,85 @@ class ChromeSetupTests(unittest.TestCase):
         detail = module.build_detail_record(job, extracted)
 
         self.assertEqual(detail["boss_active_status"], "本周活跃")
+
+    def test_merge_unique_deduplicates_by_job_id_keeping_old(self):
+        module = load_module()
+        existing = [{"job_id": "a", "title": "old-a"}, {"job_id": "b", "title": "old-b"}]
+        incoming = [{"job_id": "b", "title": "new-b"}, {"job_id": "c", "title": "new-c"}]
+
+        merged = module.merge_unique(existing, incoming)
+
+        self.assertEqual([j["job_id"] for j in merged], ["a", "b", "c"])
+        self.assertEqual(merged[1]["title"], "old-b", "同 id 应保留旧记录")
+
+    def test_merge_unique_new_overrides_old(self):
+        module = load_module()
+        existing = [{"job_id": "a", "title": "old-a"}]
+        incoming = [{"job_id": "a", "title": "new-a"}, {"job_id": "b", "title": "new-b"}]
+
+        merged = module.merge_unique(existing, incoming, new_overrides=True)
+
+        self.assertEqual([j["job_id"] for j in merged], ["a", "b"])
+        self.assertEqual(merged[0]["title"], "new-a", "同 id 应保留新记录")
+
+    def test_merge_unique_skips_non_dict_items_without_crashing(self):
+        module = load_module()
+        existing = [{"job_id": "a", "title": "old-a"}, "not-a-dict"]
+        incoming = [None, {"job_id": "b", "title": "new-b"}, 42]
+
+        merged = module.merge_unique(existing, incoming)
+        # existing 非 dict 项原样保留（不静默丢弃旧数据），incoming 非 dict 项跳过
+        self.assertEqual(len(merged), 3)
+        dict_items = [j for j in merged if isinstance(j, dict)]
+        self.assertEqual([j["job_id"] for j in dict_items], ["a", "b"])
+
+    def test_atomic_write_json_writes_payload_and_cleans_tmp(self):
+        module = load_module()
+        with tempfile_profile() as paths:
+            target = str(paths["cdp_profile"] / "out.json")
+            payload = {"jobs": [{"job_id": "a"}]}
+
+            module._atomic_write_json(target, payload)
+
+            with open(target, "r", encoding="utf-8") as f:
+                self.assertEqual(json.load(f), payload)
+            leftovers = [
+                name for name in os.listdir(paths["cdp_profile"])
+                if name.startswith("out.json.tmp")
+            ]
+            self.assertEqual(leftovers, [], "失败/成功路径都不应残留 .tmp 文件")
+
+    def test_atomic_write_json_preserves_original_on_serialize_failure(self):
+        module = load_module()
+        with tempfile_profile() as paths:
+            target = str(paths["cdp_profile"] / "out.json")
+            os.makedirs(paths["cdp_profile"], exist_ok=True)
+            with open(target, "w", encoding="utf-8") as f:
+                f.write('{"keep": true}')
+
+            with mock.patch.object(
+                module.json, "dump", side_effect=TypeError("cannot serialize")
+            ):
+                with self.assertRaises(TypeError):
+                    module._atomic_write_json(target, {"bad": object()})
+
+            with open(target, "r", encoding="utf-8") as f:
+                self.assertEqual(json.load(f), {"keep": True}, "失败时不应破坏原文件")
+
+    def test_flush_jobs_deduplicates_across_incremental_writes(self):
+        module = load_module()
+        with tempfile_profile() as paths:
+            target = str(paths["cdp_profile"] / "jobs.json")
+            meta = {"keyword": "Java"}
+
+            module.flush_jobs(target, dict(meta), [{"job_id": "a"}, {"job_id": "b"}])
+            module.flush_jobs(target, dict(meta), [{"job_id": "b"}, {"job_id": "c"}])
+
+            with open(target, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.assertEqual([j["job_id"] for j in data["jobs"]], ["a", "b", "c"])
+            self.assertEqual(data["total"], 3)
+            self.assertEqual(data["keyword"], "Java")
 
     def test_detail_extractor_never_uses_body_text_as_jd_fallback(self):
         module = load_module()
@@ -1118,10 +1205,9 @@ class ChromeSetupTests(unittest.TestCase):
         fake_requests.get.return_value = type("Resp", (), {"status_code": 200})()
 
         with tempfile_profile() as paths:
-            ps_output = (
-                "123 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome "
-                "--remote-debugging-port=9333 --user-data-dir=/tmp/chrome-cdp-data\n"
-            )
+            ps_output = process_query_stdout([
+                (123, chrome_cmdline(9333, "/tmp/chrome-cdp-data")),
+            ])
             with mock.patch.object(module, "DEFAULT_CDP_DATA_DIR", str(paths["cdp_profile"])), \
                     mock.patch.object(module, "requests", fake_requests), \
                     mock.patch.object(module.subprocess, "run", return_value=type("Completed", (), {"stdout": ps_output, "returncode": 0})()), \
@@ -1136,10 +1222,9 @@ class ChromeSetupTests(unittest.TestCase):
         fake_requests.get.return_value = type("Resp", (), {"status_code": 200})()
 
         with tempfile_profile() as paths:
-            ps_output = (
-                "123 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome "
-                f"--remote-debugging-port=9333 --user-data-dir={paths['cdp_profile']}\n"
-            )
+            ps_output = process_query_stdout([
+                (123, chrome_cmdline(9333, str(paths["cdp_profile"]))),
+            ])
             with mock.patch.object(module, "DEFAULT_CDP_DATA_DIR", str(paths["cdp_profile"])), \
                     mock.patch.object(module, "requests", fake_requests), \
                     mock.patch.object(module.subprocess, "run", return_value=type("Completed", (), {"stdout": ps_output, "returncode": 0})()), \
@@ -1156,10 +1241,9 @@ class ChromeSetupTests(unittest.TestCase):
         fake_requests.get.return_value = type("Resp", (), {"status_code": 200})()
 
         with tempfile_profile() as paths:
-            ps_output = (
-                "123 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome "
-                f"--remote-debugging-port=9333 --user-data-dir={paths['cdp_profile']}\n"
-            )
+            ps_output = process_query_stdout([
+                (123, chrome_cmdline(9333, str(paths["cdp_profile"]))),
+            ])
             with mock.patch.object(module, "DEFAULT_CDP_DATA_DIR", str(paths["cdp_profile"])), \
                     mock.patch.object(module, "requests", fake_requests), \
                     mock.patch.object(module.subprocess, "run", return_value=type("Completed", (), {"stdout": ps_output, "returncode": 0})()), \
@@ -1172,12 +1256,10 @@ class ChromeSetupTests(unittest.TestCase):
         module = load_module()
 
         with tempfile_profile() as paths:
-            ps_output = (
-                "123 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome "
-                f"--remote-debugging-port=9333 --user-data-dir={paths['cdp_profile']}\n"
-                "456 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome "
-                "--remote-debugging-port=9334 --user-data-dir=/tmp/other-profile\n"
-            )
+            ps_output = process_query_stdout([
+                (123, chrome_cmdline(9333, str(paths["cdp_profile"]))),
+                (456, chrome_cmdline(9334, "/tmp/other-profile")),
+            ])
             with mock.patch.object(module.subprocess, "run", return_value=type("Completed", (), {"stdout": ps_output, "returncode": 0})()):
                 self.assertEqual(module.chrome_pids_for_user_data_dir(str(paths["cdp_profile"])), [123])
                 self.assertEqual(module.chrome_user_data_dirs_for_cdp_port(9333), [str(paths["cdp_profile"])])
@@ -1272,6 +1354,8 @@ class ChromeSetupTests(unittest.TestCase):
             [sys.executable, str(SCRIPT_PATH), "--help"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
 
@@ -1312,6 +1396,30 @@ class tempfile_profile:
 def fake_run(calls, *args, **kwargs):
     calls["run"].append(args[0])
     return type("Completed", (), {"stdout": "", "returncode": 0})()
+
+
+def chrome_cmdline(cdp_port, user_data_dir):
+    """返回符合当前平台的 chrome 命令行（unquoted user-data-dir，测试 unquoted 解析）。"""
+    if platform.system() == "Windows":
+        exe = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+        return f'{exe} --remote-debugging-port={cdp_port} --user-data-dir={user_data_dir}'
+    return (
+        f"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome "
+        f"--remote-debugging-port={cdp_port} --user-data-dir={user_data_dir}"
+    )
+
+
+def process_query_stdout(entries):
+    """把 (pid, cmdline) 列表转成 iter_chrome_process_commands 当前平台的 mock 输出。
+
+    Windows 分支解析 PowerShell ConvertTo-Json 输出；POSIX 分支解析 ps 行文本。
+    这两个分支的输出格式不同，测试必须按平台提供对应格式，否则在另一平台解析为空。
+    """
+    if platform.system() == "Windows":
+        return json.dumps(
+            [{"ProcessId": pid, "CommandLine": cmdline} for pid, cmdline in entries]
+        )
+    return "".join(f"{pid} {cmdline}\n" for pid, cmdline in entries)
 
 
 ROOT_PATH = SCRIPT_PATH.parents[1]

--- a/tests/test_job_summary.py
+++ b/tests/test_job_summary.py
@@ -9,6 +9,12 @@ import unittest
 from unittest import mock
 
 
+# 同 tests/test_chrome_setup.py：Windows GBK 控制台无法编码 emoji，统一重配 UTF-8。
+for _stream in (sys.stdout, sys.stderr):
+    if _stream is not None and hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 ROOT_PATH = pathlib.Path(__file__).resolve().parents[1]
 SUMMARY_SCRIPT_PATH = ROOT_PATH / "scripts" / "job_summary.py"
 


### PR DESCRIPTION
Fix #51：Windows 兼容与数据安全修复。

## 改了什么

### 1. GBK 控制台崩溃（#51 问题 1）
`main()`（及 `job_summary.py` 入口）将 stdout/stderr 重配为 UTF-8（`errors="replace"`）。Windows 默认 GBK 代码页无法编码 emoji（✅❌⚠️ 等），此前 `--setup-chrome` / `--check` / 抓取完成提示直接 `UnicodeEncodeError` 崩溃。实测基线：73 个单测中 8 个因此 ERROR。

### 2. JSON 落盘原子化（#51 问题 2）
新增 `_atomic_write_json`（临时文件 + `os.replace`，成功/失败均清理 .tmp）。`flush_jobs`、详情页逐条落盘、`--merge` 详情落盘统一接入。抓取中断（Ctrl+C/断电）不再留下半截 JSON 覆盖旧数据。

### 3. 死代码与重复实现收敛（#51 问题 3）
- 删除无调用方的 `append_json`
- `flush_jobs` / `merge_jobs` / `merge_details_from_lists` 的「读-去重-写」收敛到 `merge_unique`
- `parse_jobs_eval_value` 与 `parse_api_jobs_eval_value` 合并（smoke test 改用后者，行为不变）
- `--check` 的 CDP 检查不再把任意 CDP 服务误报为 Chrome

### 4. 测试平台适配
`tests/test_chrome_setup.py` 新增 `chrome_cmdline()` / `process_query_stdout()` helper 按平台生成进程查询 mock（Windows: PowerShell JSON；POSIX: ps 文本），修复 Windows 上 3 个既有测试失败；测试文件 stdout 重配 UTF-8，不再依赖外部 `PYTHONIOENCODING`。新增 `merge_unique` / `_atomic_write_json` / `flush_jobs` 单元测试。

## 为什么改
项目 README 声明"Windows 代码分支已预留，未经实测"，实测发现上述问题直接导致 Windows 用户无法使用（崩溃/丢数据）。

## 怎么测试的
- `python -m unittest tests.test_chrome_setup tests.test_job_summary` → **92 tests 全部通过**（基线 73 tests: 1 failure + 8 errors，均在 Windows）
- `python -m py_compile scripts/boss_cdp_raw.py scripts/job_summary.py` 通过
- cmd 936（GBK 代码页）下实测 `--help` / `--version` / `--list-cities` / `--check`：退出码 0，无 UnicodeEncodeError
- 不新增依赖（仍仅 requests + websocket-client）

## 影响范围
- 修改：`scripts/boss_cdp_raw.py`、`scripts/job_summary.py`、`tests/test_chrome_setup.py`、`tests/test_job_summary.py`、`CHANGELOG.md`
- 不修改：列表/详情抓取逻辑、CDP target 管理、登录探测状态机、请求节奏与合规行为、城市码表、CSV 输出格式、CLI 参数

> 说明：本次修复覆盖 Windows 上"脚本本身"的崩溃与数据安全问题；Windows 上的真实抓取链路可参考 #30 中 @lincannm 的成功记录（与代理出口 IP 风控相关，与本修复正交）。