### PR TITLE
fix: 列表抓取与登录探测改为 Network 域被动捕获，消除注入 XHR 触发的 code 37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 未发布
 
+### 变更
+- 列表抓取与登录探测全面改为**被动捕获**（#53/#30）：不再向页面注入同步 XHR（该请求模式会被 BOSS 风控识别为 code 37），改为导航真实搜索页后通过 CDP `Network` 域旁听页面自身发出的 `joblist.json` 响应；翻页改为滚动触发页面自身的无限滚动加载（每页 15 条，`hasMore=false` 时提前结束）。字段映射逻辑从注入 JS 模板迁至 Python（`map_api_job`）
+- 登录/风控判定并入首次真实搜索响应（`LoginGateError`）：正式抓取不再预先发送固定 `Java/上海` 登录探测，消除一次无关请求；`--check`、`--setup-chrome` 的探测同样改为被动捕获，消息与退出语义不变
+- 后台标签页开启 `Emulation.setFocusEmulationEnabled` 焦点仿真：页面自身的无限滚动加载在真实后台（不可见、无焦点）状态下不触发，仿真后 `document.hidden=false / visibilityState=visible / hasFocus=true`，且不激活窗口、不抢前台焦点
+- 删除死代码：`FETCH_API_JS_TEMPLATE`、`build_login_probe_url`、`parse_api_jobs_eval_value`、`should_use_dom_fallback`；`CDPSession` 新增事件缓冲与 `drain_events`；测试从 92 增至 96 个
+
 ### 新增
 - 详情/列表结果新增独立字段 `boss_active_status`（如「今日活跃」「在线」）：列表兼容 `activeTimeDesc` 与 `bossOnline`（仅在线时映射为「在线」）；详情页从招聘者卡片解析更细粒度状态并优先保留；JD 正文仍剔除该行，不混入描述
 - 新增 `--stop-chrome` 命令：抓取/分析完成后关闭 BOSS 专用 CDP Chrome（按 user-data-dir 精准匹配隔离 profile，不碰主 Chrome）；抓取命令新增 `--close-chrome` 选项，正常结束后自动收尾（默认关闭，异常退出不触发以保留登录态）。复用已有 `stop_cdp_chrome` 的安全匹配逻辑，补齐进程关闭/收尾链路的单元测试。（#26）

--- a/README.en.md
+++ b/README.en.md
@@ -227,8 +227,8 @@ boss-zhipin-scraper/
 This is a Chrome-CDP-based BOSS Zhipin crawler. Core flow:
 
 1. Connect to an already-open Chrome via the Chrome DevTools Protocol (CDP)
-2. Inject JS inside the BOSS Zhipin page that calls the search API via synchronous XHR
-3. The API returns plaintext `salaryDesc`, bypassing the front-end font obfuscation
+2. Navigate to the real search page and **passively capture the page's own search-API responses** via the CDP `Network` domain (no injected requests, avoiding BOSS risk-control flags on injected XHRs)
+3. Pagination scrolls the page to trigger its own infinite-scroll loading and keeps listening; the API returns plaintext `salaryDesc`, bypassing the front-end font obfuscation
 4. The list API preserves `securityId` / `lid` context, carried into the detail page
 5. Each page is written to disk immediately, deduped by `job_id`
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ boss-zhipin-scraper/
 这是一个基于 Chrome CDP 的 BOSS直聘爬虫，核心流程：
 
 1. 通过 Chrome DevTools Protocol (CDP) 连接到已打开的 Chrome
-2. 在 BOSS直聘页面内注入 JS，用同步 XHR 调用搜索 API
-3. API 返回明文 `salaryDesc`，绕过前端字体反爬
+2. 导航到真实搜索页，通过 CDP `Network` 域**被动捕获页面自身发出的搜索 API 响应**（不发任何注入请求，规避 BOSS 对注入 XHR 的风控识别）
+3. 翻页通过滚动触发页面自身的无限滚动加载，继续旁听其请求；API 返回明文 `salaryDesc`，绕过前端字体反爬
 4. 列表 API 保留 `securityId` / `lid` 等上下文，进入详情页时带上这些参数
 5. 每页抓完立即写入文件，按 `job_id` 去重
 

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -26,6 +26,7 @@ import time
 import random
 import sys
 import argparse
+import base64
 import os
 import re
 import hashlib
@@ -118,9 +119,10 @@ LOGIN_PROBE_TARGETS = (
     ("AI Agent", "101010100"),
     ("产品经理", "101280600"),
 )
-LOGIN_PROBE_PAGE_SIZE = 10
 LOGIN_PROBE_MAX_INTERVAL = 15
 LOGIN_PROBE_MAX_TRANSIENT_ERRORS = 2
+# 被动捕获页面自身首次搜索响应的等待上限：导航 + SPA 发请求通常 <8s，留足余量
+PROBE_CAPTURE_TIMEOUT = 25
 LOGIN_RESTRICTED_CODES = {31, 37}
 # BOSS 风控码会随平台策略变化，码表追不上时按 message 关键字兜底识别风控/限流，
 # 避免把「已登录但被风控」误判为 RESPONSE_ERROR 进而当成登录失败。
@@ -291,6 +293,9 @@ class CDPSession:
         ws_url = resp.json()["webSocketDebuggerUrl"]
         self.ws = websocket.create_connection(ws_url, timeout=60)
         self.mid = 0
+        # CDP 事件缓冲：send() 等待命令响应期间到达的事件通知都会存这里，
+        # 供 Network 域被动捕获使用（见 NetworkJoblistCapture）。
+        self.events = []
 
     def send(self, method, params=None, sid=None, timeout=30):
         """发送 CDP 命令并等待匹配的响应。
@@ -339,13 +344,40 @@ class CDPSession:
             if r.get("id") == self.mid:
                 return r
 
-            # 不匹配的消息：可能是事件通知，记录并跳过
+            # 不匹配的消息：事件通知，存入缓冲供被动捕获，避免丢失
             event_name = r.get("method", "unknown")
-            log.debug(f"跳过不匹配消息 (id={r.get('id')}, event={event_name})")
+            log.debug(f"缓冲事件消息 (id={r.get('id')}, event={event_name})")
+            self.events.append(r)
 
         raise TimeoutError(
             f"CDP send({method}) 在 {max_retries} 条消息内未找到匹配响应"
         )
+
+    def drain_events(self, duration):
+        """在 duration 秒内持续接收并缓冲 CDP 事件，超时或期间无消息则返回。
+
+        用于等待页面自身发起的请求完成（Network 域事件），不发送任何命令。
+        """
+        deadline = time.time() + duration
+        try:
+            while True:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    return
+                self.ws.settimeout(min(0.5, remaining))
+                try:
+                    raw = self.ws.recv()
+                except websocket.WebSocketTimeoutException:
+                    continue
+                try:
+                    r = json.loads(raw)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if "method" in r:
+                    self.events.append(r)
+        finally:
+            # 恢复默认超时，避免影响后续 send() 的等待
+            self.ws.settimeout(60)
 
     def eval_js(self, js, sid):
         r = self.send("Runtime.evaluate", {"expression": js, "returnByValue": True}, sid)
@@ -382,6 +414,18 @@ def create_page_session(cdp, background=True):
     )
     session_id = attached["result"]["sessionId"]
     if background:
+        # 焦点仿真：让后台标签页在页面看来是「可见且有焦点」的
+        # （document.hidden=false / visibilityState=visible / hasFocus=true）。
+        # BOSS 搜索页的无限滚动加载会被真实的后台状态挡住，页面不发下一页请求；
+        # 仿真不激活窗口、不抢用户前台焦点（区别于 Target.activateTarget）。
+        try:
+            cdp.send(
+                "Emulation.setFocusEmulationEnabled",
+                {"enabled": True},
+                session_id,
+            )
+        except (websocket.WebSocketException, TimeoutError):
+            log.debug("setFocusEmulationEnabled 失败，回退仅 JS 可见性覆盖", exc_info=True)
         cdp.send(
             "Page.addScriptToEvaluateOnNewDocument",
             {"source": BACKGROUND_VISIBILITY_SCRIPT},
@@ -391,49 +435,154 @@ def create_page_session(cdp, background=True):
 
 
 # ============================================================
-# 通过页面内 XHR 调 API 获取列表数据（明文薪资）
+# 被动捕获页面自身的列表 API 响应（Network 域旁听，不发额外请求）
+#
+# 背景（#53）：程序注入的同步 XHR 与页面自身请求特征不同，会被 BOSS 风控
+# 识别为异常环境（code 37）。改为导航真实搜索页 + 滚动加载，仅旁听页面
+# 自己发出的 /wapi/zpgeek/search/joblist.json 响应，全程零注入请求。
 # ============================================================
-FETCH_API_JS_TEMPLATE = """
-(function(){
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', '__API_URL__', false);
-    xhr.send();
-    if (xhr.status !== 200) return JSON.stringify([{error: xhr.status}]);
-    var data = JSON.parse(xhr.responseText);
-    var jobs = (data.zpData || {}).jobList || [];
-    var results = jobs.map(function(j) {
-        return {
-            title: j.jobName || '',
-            salary: j.salaryDesc || '',
-            salary_source: j.salaryDesc ? 'api' : 'api_empty',
-            location: (j.cityName || '') + '\\u00b7' + (j.areaDistrict || '') + '\\u00b7' + (j.businessDistrict || ''),
-            tags: [j.jobExperience || '', j.jobDegree || ''].filter(function(t){return t && t !== '\\u4e0d\\u9650';}).join(' | '),
-            boss_name: j.brandName || '',
-            boss_title: j.bossTitle || '',
-            boss_active_status: j.activeTimeDesc || (j.bossOnline ? '\\u5728\\u7ebf' : ''),
-            company_scale: j.brandScaleName || '',
-            company_stage: j.brandStageName || '',
-            company_industry: j.brandIndustry || '',
-            job_labels: (j.jobLabels || []).join(' | '),
-            skills: (j.skills || []).join(' | '),
-            security_id: j.securityId || '',
-            lid: j.lid || '',
-            encrypt_job_id: j.encryptJobId || '',
-            encrypt_boss_id: j.encryptBossId || '',
-            encrypt_brand_id: j.encryptBrandId || '',
-            job_link: j.encryptJobId ? 'https://www.zhipin.com/job_detail/' + j.encryptJobId + '.html' : '',
-            company_link: j.encryptBrandId ? 'https://www.zhipin.com/gongsi/' + j.encryptBrandId + '.html' : '',
-            welfare: (j.welfareList || []).join(' | ')
-        };
-    });
-    return JSON.stringify(results);
-})()
-"""
+class NetworkJoblistCapture:
+    """监听并捕获页面自身发出的 joblist API 响应。
+
+    依赖 ``CDPSession.events`` 事件缓冲：send() 执行其它命令期间到达的
+    Network 事件已自动入缓冲，wait_next_response() 再补充等待窗口。
+    """
+
+    def __init__(self, cdp, sid):
+        self.cdp = cdp
+        self.sid = sid
+        self._consumed = set()   # 已返回给调用方的 requestId
+
+    def enable(self):
+        self.cdp.send("Network.enable", {}, self.sid)
+
+    def _next_completed(self):
+        """扫描事件缓冲，返回下一个已完成且未消费的 joblist 响应 requestId。"""
+        requests = {}
+        finished = set()
+        for ev in self.cdp.events:
+            method = ev.get("method", "")
+            params = ev.get("params", {})
+            if method == "Network.requestWillBeSent":
+                if self._is_joblist_url(params.get("request", {}).get("url", "")):
+                    requests[params.get("requestId")] = True
+            elif method == "Network.loadingFinished":
+                finished.add(params.get("requestId"))
+        for request_id in requests:
+            if request_id in finished and request_id not in self._consumed:
+                return request_id
+        return None
+
+    @staticmethod
+    def _is_joblist_url(url):
+        return API_JOB_LIST_PATH in url
+
+    def wait_next_response(self, timeout, trigger=None, poll=0.5):
+        """等待下一个未消费的 joblist 响应并解析 JSON。
+
+        Args:
+            timeout: 最长等待秒数
+            trigger: 等待前执行一次的触发动作（如导航/滚动），页面将自行发请求
+            poll: 每轮事件等待窗口
+
+        Returns:
+            dict: 解析后的响应 JSON；超时未捕获返回 None
+        """
+        if trigger is not None:
+            trigger()
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            request_id = self._next_completed()
+            if request_id is None:
+                self.cdp.drain_events(min(poll, deadline - time.time()))
+                continue
+            self._consumed.add(request_id)
+            body = self._fetch_body(request_id)
+            if body is None:
+                continue
+            try:
+                return json.loads(body)
+            except (json.JSONDecodeError, ValueError) as e:
+                log.warning(f"joblist 响应不是有效 JSON: {e}")
+        return None
+
+    def _fetch_body(self, request_id):
+        try:
+            result = self.cdp.send(
+                "Network.getResponseBody", {"requestId": request_id}, self.sid
+            )
+        except (websocket.WebSocketException, TimeoutError) as e:
+            log.debug(f"读取响应体失败 request={request_id}: {e}")
+            return None
+        body = result.get("result", {}).get("body", "")
+        if result.get("result", {}).get("base64Encoded"):
+            try:
+                body = base64.b64decode(body).decode("utf-8", errors="replace")
+            except (ValueError, TypeError) as e:
+                log.debug(f"响应体 base64 解码失败: {e}")
+                return None
+        return body
+
+
+def map_api_job(raw):
+    """把 joblist.json 原始条目映射为统一的 job 字典（原注入 JS 模板逻辑的 Python 版）。"""
+    if not isinstance(raw, dict):
+        return None
+
+    encrypt_job_id = str(raw.get("encryptJobId") or "")
+    encrypt_brand_id = str(raw.get("encryptBrandId") or "")
+    return {
+        "title": raw.get("jobName") or "",
+        "salary": raw.get("salaryDesc") or "",
+        "salary_source": "api" if raw.get("salaryDesc") else "api_empty",
+        "location": "\u00b7".join([
+            raw.get("cityName") or "",
+            raw.get("areaDistrict") or "",
+            raw.get("businessDistrict") or "",
+        ]),
+        "tags": " | ".join(
+            t for t in (raw.get("jobExperience") or "", raw.get("jobDegree") or "")
+            if t and t != "不限"
+        ),
+        "boss_name": raw.get("brandName") or "",
+        "boss_title": raw.get("bossTitle") or "",
+        "boss_active_status": map_list_boss_active_status(raw),
+        "company_scale": raw.get("brandScaleName") or "",
+        "company_stage": raw.get("brandStageName") or "",
+        "company_industry": raw.get("brandIndustry") or "",
+        "job_labels": " | ".join(raw.get("jobLabels") or []),
+        "skills": " | ".join(raw.get("skills") or []),
+        "security_id": raw.get("securityId") or "",
+        "lid": raw.get("lid") or "",
+        "encrypt_job_id": encrypt_job_id,
+        "encrypt_boss_id": str(raw.get("encryptBossId") or ""),
+        "encrypt_brand_id": encrypt_brand_id,
+        "job_link": (
+            f"https://www.zhipin.com/job_detail/{encrypt_job_id}.html"
+            if encrypt_job_id else ""
+        ),
+        "company_link": (
+            f"https://www.zhipin.com/gongsi/{encrypt_brand_id}.html"
+            if encrypt_brand_id else ""
+        ),
+        "welfare": " | ".join(raw.get("welfareList") or []),
+    }
+
+
+def map_api_jobs(data):
+    """从捕获的 joblist 响应 JSON 提取映射后的职位列表。"""
+    if not isinstance(data, dict):
+        return []
+    job_list = (data.get("zpData") or {}).get("jobList")
+    if not isinstance(job_list, list):
+        return []
+    return [j for j in (map_api_job(item) for item in job_list) if j]
+
 
 # ============================================================
 # DEPRECATED: DOM 提取作为 fallback（薪资可能是加密字体）
-# 此方法已弃用，仅作为 API 方式失败时的最后降级手段。
-# 新代码应优先使用 FETCH_API_JS_TEMPLATE 通过 API 获取数据。
+# 此方法已弃用，仅作为 Network 捕获无响应时的最后降级手段。
+# 新代码应优先使用 NetworkJoblistCapture 被动捕获页面自身的 API 响应。
 # ============================================================
 EXTRACT_LIST_JS = """
 (function(){
@@ -799,6 +948,10 @@ def list_cities(keyword=None, use_live=True):
         print(f"  {name}\t{code}")
 
 
+class LoginGateError(Exception):
+    """首次搜索响应判定登录/风控不可用，抓取需要终止（消息已格式化好可直接打印）。"""
+
+
 class LoginProbeStatus(Enum):
     """Outcome of one login probe request."""
 
@@ -893,70 +1046,29 @@ def is_logged_in_search_response(data):
     return result.status is LoginProbeStatus.AVAILABLE
 
 
-def build_login_probe_url(query, city_code):
-    params = {
-        "scene": 1,
-        "query": query,
-        "city": city_code,
-        "page": 1,
-        "pageSize": LOGIN_PROBE_PAGE_SIZE,
-    }
-    return f"{API_JOB_LIST_PATH}?{urlencode(params)}"
+def probe_login_state(cdp, sid, query=LOGIN_PROBE_QUERY, city_code=LOGIN_PROBE_CITY,
+                      timeout=PROBE_CAPTURE_TIMEOUT):
+    """导航搜索页并被动捕获页面自身的首次 joblist 响应，返回结构化登录态。
 
-
-def probe_login_state(cdp, sid, query=LOGIN_PROBE_QUERY, city_code=LOGIN_PROBE_CITY):
-    """Run exactly one budgeted search probe and return its structured state."""
-    probe_url = build_login_probe_url(query, city_code)
-    js = f"""
-    (function(){{
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', '{probe_url}', false);
-        xhr.send();
-        return JSON.stringify({{
-            httpStatus: xhr.status,
-            body: xhr.responseText
-        }});
-    }})()
+    不再注入 XHR（#53：注入请求会被 BOSS 风控识别为 code 37），
+    页面自己发出的请求即探测样本。
     """
-    incr_request()
-    val = cdp.eval_js(js, sid)
-    if not val:
-        return LoginProbeResult(
-            LoginProbeStatus.RESPONSE_ERROR,
-            message="探测响应为空",
-            retryable=True,
-        )
-    try:
-        envelope = json.loads(val) if isinstance(val, str) else val
-    except (json.JSONDecodeError, ValueError):
-        return LoginProbeResult(
-            LoginProbeStatus.RESPONSE_ERROR,
-            message="探测响应不是有效 JSON",
-            retryable=True,
-        )
-    if not isinstance(envelope, dict):
-        return LoginProbeResult(
-            LoginProbeStatus.RESPONSE_ERROR,
-            message="探测响应格式异常",
-            retryable=True,
-        )
+    capture = NetworkJoblistCapture(cdp, sid)
+    capture.enable()
 
-    raw_http_status = envelope.get("httpStatus", 200)
-    try:
-        http_status = int(raw_http_status)
-    except (TypeError, ValueError):
-        http_status = 0
-    body = envelope.get("body", envelope)
-    if isinstance(body, str):
-        try:
-            body = json.loads(body)
-        except (json.JSONDecodeError, ValueError):
-            return LoginProbeResult(
-                LoginProbeStatus.RESPONSE_ERROR,
-                message="搜索接口响应不是有效 JSON",
-                retryable=True,
-            )
-    return classify_login_probe_response(body, http_status=http_status)
+    def navigate():
+        url = build_search_url(query, city_code, 1, {})
+        cdp.send("Page.navigate", {"url": url}, sid)
+
+    incr_request()
+    data = capture.wait_next_response(timeout=timeout, trigger=navigate)
+    if data is None:
+        return LoginProbeResult(
+            LoginProbeStatus.RESPONSE_ERROR,
+            message="未捕获到页面自身的搜索响应",
+            retryable=True,
+        )
+    return classify_login_probe_response(data)
 
 
 def describe_login_probe_result(result):
@@ -992,10 +1104,7 @@ def check_login_state(cdp_port=DEFAULT_CDP_PORT):
         cdp = CDPSession(cdp_port)
         tid, sid = create_page_session(cdp)
 
-        # 先导航到 BOSS直聘，确保 cookie 域名正确
-        cdp.send("Page.navigate", {"url": "https://www.zhipin.com/"}, sid)
-        time.sleep(4)
-
+        # probe_login_state 会导航到真实搜索页并被动捕获页面自身的响应
         return probe_login_state(cdp, sid)
     except (requests.ConnectionError, requests.Timeout, KeyError,
             json.JSONDecodeError, websocket.WebSocketException,
@@ -1266,29 +1375,6 @@ def build_search_url(keyword, city_code, page, filters):
     return f"https://www.zhipin.com/web/geek/job?{urlencode(params)}"
 
 
-def should_use_dom_fallback(jobs, allow_dom_fallback=False):
-    return allow_dom_fallback and not jobs
-
-
-def parse_api_jobs_eval_value(value):
-    if not value:
-        return []
-    try:
-        parsed = json.loads(value) if isinstance(value, str) else value
-    except (json.JSONDecodeError, ValueError, TypeError):
-        return []
-    if not isinstance(parsed, list):
-        return []
-
-    jobs = []
-    for item in parsed:
-        if not isinstance(item, dict) or item.get("error"):
-            continue
-        if item.get("title") or item.get("job_link"):
-            jobs.append(item)
-    return jobs
-
-
 def build_detail_url(job):
     """Build the URL used for detail navigation without mutating job_link."""
     link = job.get("job_link", "")
@@ -1399,9 +1485,14 @@ def scrape_list(keyword, city_input, max_pages, filters, output_path,
     print()
 
     tid, sid = create_page_session(cdp)
+    capture = NetworkJoblistCapture(cdp, sid)
+    capture.enable()
 
-    def human_scroll(cdp, sid):
-        """模拟人类滚动: 随机次数、随机距离、随机停顿，偶尔回滚一点"""
+    def human_scroll(cdp, sid, to_bottom=False):
+        """模拟人类滚动: 随机次数、随机距离、随机停顿，偶尔回滚一点。
+
+        to_bottom=True 时最后强制滚到页面底部，触发无限滚动加载下一页。
+        """
         total_scrolls = random.randint(3, 6)
         for i in range(total_scrolls):
             # 大部分往下滚，偶尔往上回滚一点（模拟阅读回看）
@@ -1415,6 +1506,8 @@ def scrape_list(keyword, city_input, max_pages, filters, output_path,
                 time.sleep(random.uniform(2.0, 4.0))
             else:
                 time.sleep(random.uniform(0.5, 1.5))
+        if to_bottom:
+            cdp.eval_js("window.scrollTo(0, document.body.scrollHeight); void 0;", sid)
 
     def human_mouse_jitter(cdp, sid):
         """偶尔移动鼠标位置，模拟人在页面上活动"""
@@ -1425,43 +1518,68 @@ def scrape_list(keyword, city_input, max_pages, filters, output_path,
                 "type": "mouseMoved", "x": x, "y": y
             }, sid)
 
+    def gate_first_response(data):
+        """用首个真实搜索响应判定登录/风控（#53：不再单独发固定探测请求）。"""
+        result = classify_login_probe_response(data)
+        if result.status is LoginProbeStatus.AVAILABLE:
+            print("✅ 已登录\n")
+            return
+        if result.status is LoginProbeStatus.UNAUTHENTICATED:
+            raise LoginGateError(
+                "❌ 未检测到 BOSS直聘登录状态。请先在 Chrome 中登录 zhipin.com。\n"
+                "   可运行 --check 检查环境，或 --setup-chrome 启动 Chrome。"
+            )
+        if result.status is LoginProbeStatus.RESTRICTED:
+            raise LoginGateError(
+                f"❌ {describe_login_probe_result(result)}，已停止抓取。\n"
+                f"   请先在浏览器中完成验证或稍后再试，不要重复运行登录探测。"
+            )
+        if result.status is LoginProbeStatus.EMPTY:
+            print(f"⚠️  {describe_login_probe_result(result)}；继续执行实际职位搜索。\n")
+            return
+        raise LoginGateError(
+            f"❌ {describe_login_probe_result(result)}，已停止抓取。"
+        )
+
     try:
         for pg in range(1, max_pages + 1):
             print(f"--- [{pg}/{max_pages} 页, {len(all_jobs)} 条已抓] ---")
-            incr_request()
 
-            # 第一页：导航到搜索页建立 cookie/session
             if pg == 1:
+                # 导航真实搜索页，被动等待页面自己发出首个 joblist 请求
                 url = build_search_url(keyword, city_code, pg, filters)
-                cdp.send("Page.navigate", {"url": url}, sid)
-                time.sleep(random.uniform(6, 10))
-                human_scroll(cdp, sid)
-                human_mouse_jitter(cdp, sid)
 
-            # 优先用 API 获取明文数据
-            api_params = {
-                "scene": "1",
-                "query": keyword,
-                "city": city_code,
-                "page": pg,
-                "pageSize": 30,
-            }
-            for k, v in filters.items():
-                if v:
-                    api_params[k] = v
-            api_url = f"{API_JOB_LIST_PATH}?{urlencode(api_params)}"
-            api_js = FETCH_API_JS_TEMPLATE.replace("__API_URL__", api_url)
-            val = cdp.eval_js(api_js, sid)
+                def trigger_navigate():
+                    cdp.send("Page.navigate", {"url": url}, sid)
+                    time.sleep(random.uniform(2, 4))
 
-            jobs = parse_api_jobs_eval_value(val)
+                data = capture.wait_next_response(
+                    timeout=PROBE_CAPTURE_TIMEOUT, trigger=trigger_navigate
+                )
+                incr_request()
+                if data is None:
+                    # 捕获超时：页面可能被重定向到验证/登录页，交由 DOM 兜底
+                    log.warning("⚠️ 未捕获到页面自身的搜索响应")
+                else:
+                    gate_first_response(data)
+            else:
+                # 翻页：滚动到底触发无限滚动加载，继续旁听页面自身请求
+                human_scroll(cdp, sid, to_bottom=True)
+                data = capture.wait_next_response(timeout=20)
+                incr_request()
+
+            reached_end = (
+                isinstance(data, dict)
+                and (data.get("zpData") or {}).get("hasMore") is False
+            )
+
+            jobs = map_api_jobs(data) if data is not None else []
 
             # DOM 提取的薪资可能是加密字体，默认禁用；只有显式允许时才降级。
-            if should_use_dom_fallback(jobs, allow_dom_fallback):
-                log.warning("⚠️ API 获取失败，回退到 DOM 提取（此方式已弃用，数据可能不完整）")
-                if pg > 1:
-                    url = build_search_url(keyword, city_code, pg, filters)
-                    cdp.send("Page.navigate", {"url": url}, sid)
-                    time.sleep(random.uniform(4, 8))
+            if not jobs and allow_dom_fallback:
+                log.warning("⚠️ 未捕获到 API 职位数据，回退到 DOM 提取（此方式已弃用，数据可能不完整）")
+                if data is None:
+                    time.sleep(random.uniform(2, 4))
                     human_scroll(cdp, sid)
                 val = cdp.eval_js(EXTRACT_LIST_JS, sid)
                 if val:
@@ -1471,7 +1589,10 @@ def scrape_list(keyword, city_input, max_pages, filters, output_path,
                         print(f"  ⚠️ JSON 解析失败")
                         jobs = []
             elif not jobs:
-                log.warning("⚠️ API 未返回职位数据，已跳过 DOM fallback；如需强制降级可加 --allow-dom-fallback")
+                log.warning("⚠️ 未捕获到职位数据，已跳过 DOM fallback；如需强制降级可加 --allow-dom-fallback")
+
+            if pg == 1:
+                human_mouse_jitter(cdp, sid)
 
             if not jobs:
                 print("  ⚠️ 无数据")
@@ -1505,6 +1626,10 @@ def scrape_list(keyword, city_input, max_pages, filters, output_path,
                     "filter_desc": filter_desc,
                     "scraped_at": datetime.now().isoformat(),
                 }, all_jobs)
+
+            if reached_end:
+                print("  已到最后一页（hasMore=false），提前结束\n")
+                break
 
             if pg < max_pages:
                 d = random.uniform(12, 22)
@@ -1903,18 +2028,24 @@ def run_smoke_test(cdp_port=DEFAULT_CDP_PORT):
     try:
         cdp = CDPSession(cdp_port)
         city_name, city_code = resolve_city(DEFAULT_CITY_INPUT)
-        search_url = build_search_url(LOGIN_PROBE_QUERY, city_code, 1, {})
         tid, sid = create_page_session(cdp)
+        capture = NetworkJoblistCapture(cdp, sid)
+        capture.enable()
 
         print(f"打开 BOSS 搜索页: {LOGIN_PROBE_QUERY} @ {city_name}")
-        cdp.send("Page.navigate", {"url": search_url}, sid)
-        time.sleep(4)
-        api_url = f"{API_JOB_LIST_PATH}?{urlencode({'scene': '1', 'query': LOGIN_PROBE_QUERY, 'city': city_code, 'page': 1, 'pageSize': 5})}"
-        api_js = FETCH_API_JS_TEMPLATE.replace("__API_URL__", api_url)
-        jobs = parse_api_jobs_eval_value(cdp.eval_js(api_js, sid))
+        search_url = build_search_url(LOGIN_PROBE_QUERY, city_code, 1, {})
+
+        def trigger_navigate():
+            cdp.send("Page.navigate", {"url": search_url}, sid)
+
+        data = capture.wait_next_response(timeout=PROBE_CAPTURE_TIMEOUT, trigger=trigger_navigate)
         cdp.send("Target.closeTarget", {"targetId": tid})
         cdp.close()
 
+        if data is None:
+            print("❌ Smoke test 未捕获到页面自身的搜索响应；请检查登录态或 BOSS 页面行为")
+            return 1
+        jobs = map_api_jobs(data)
         if has_usable_smoke_jobs(jobs):
             sample = next(job for job in jobs if job.get("salary") and job.get("job_link"))
             print(f"✅ Smoke test 通过: {sample.get('title')} | {sample.get('salary')}")
@@ -2473,30 +2604,17 @@ def main():
             list_data = json.load(f)
         print(f"从文件加载 {len(list_data.get('jobs',[]))} 条: {args.input}")
     else:
-        # 登录状态检测
+        # 登录/风控判定并入首个真实搜索响应（#53：不再单独发固定关键词的探测请求）
         print("检测登录状态...")
-        login_result = check_login_state(args.cdp_port)
-        if login_result.status is LoginProbeStatus.UNAUTHENTICATED:
-            print("❌ 未检测到 BOSS直聘登录状态。请先在 Chrome 中登录 zhipin.com。")
-            print(f"   可运行 --check 检查环境，或 --setup-chrome 启动 Chrome。")
+        try:
+            list_data = scrape_list(
+                args.keyword, args.city, args.pages, filters, args.output,
+                cdp_port=args.cdp_port, fmt=args.format,
+                allow_dom_fallback=args.allow_dom_fallback,
+            )
+        except LoginGateError as e:
+            print(str(e))
             sys.exit(1)
-        if login_result.status is LoginProbeStatus.RESTRICTED:
-            print(f"❌ {describe_login_probe_result(login_result)}，已停止抓取。")
-            print("   请先在浏览器中完成验证或稍后再试，不要重复运行登录探测。")
-            sys.exit(1)
-        if login_result.status is LoginProbeStatus.RESPONSE_ERROR:
-            print(f"❌ {describe_login_probe_result(login_result)}，已停止抓取。")
-            sys.exit(1)
-        if login_result.status is LoginProbeStatus.EMPTY:
-            print(f"⚠️  {describe_login_probe_result(login_result)}；继续执行实际职位搜索。\n")
-        else:
-            print("✅ 已登录\n")
-
-        list_data = scrape_list(
-            args.keyword, args.city, args.pages, filters, args.output,
-            cdp_port=args.cdp_port, fmt=args.format,
-            allow_dom_fallback=args.allow_dom_fallback,
-        )
 
     # 合并外部文件
     merged_details = None

--- a/tests/test_chrome_setup.py
+++ b/tests/test_chrome_setup.py
@@ -5,9 +5,11 @@ import json
 import os
 import pathlib
 import platform
+import random
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stdout
 from unittest import mock
@@ -58,6 +60,7 @@ class ChromeSetupTests(unittest.TestCase):
             {"result": {"targetId": "target-1"}},
             {"result": {"sessionId": "session-1"}},
             {"result": {}},
+            {"result": {}},
         ]
 
         result = module.create_page_session(cdp)
@@ -73,6 +76,12 @@ class ChromeSetupTests(unittest.TestCase):
                 mock.call(
                     "Target.attachToTarget",
                     {"targetId": "target-1", "flatten": True},
+                ),
+                # 后台标签页开启焦点仿真：无限滚动加载依赖页面可见且有焦点
+                mock.call(
+                    "Emulation.setFocusEmulationEnabled",
+                    {"enabled": True},
+                    "session-1",
                 ),
                 mock.call(
                     "Page.addScriptToEvaluateOnNewDocument",
@@ -754,13 +763,17 @@ class ChromeSetupTests(unittest.TestCase):
             "",
         )
 
-    def test_fetch_api_js_maps_bossonline_fallback(self):
+    def test_map_api_job_maps_bossonline_fallback(self):
         module = load_module()
-        js = module.FETCH_API_JS_TEMPLATE
 
-        self.assertIn("j.activeTimeDesc", js)
-        self.assertIn("j.bossOnline", js)
-        self.assertIn("boss_active_status: j.activeTimeDesc || (j.bossOnline ?", js)
+        with_desc = module.map_api_job({"jobName": "A", "activeTimeDesc": "今日活跃"})
+        self.assertEqual(with_desc["boss_active_status"], "今日活跃")
+
+        online_only = module.map_api_job({"jobName": "B", "bossOnline": True})
+        self.assertEqual(online_only["boss_active_status"], "在线")
+
+        neither = module.map_api_job({"jobName": "C"})
+        self.assertEqual(neither["boss_active_status"], "")
 
     def test_extract_job_description_removes_recruiter_card_before_safety_footer(self):
         module = load_module()
@@ -812,47 +825,182 @@ class ChromeSetupTests(unittest.TestCase):
 
     def test_api_extraction_keeps_detail_context_fields(self):
         module = load_module()
+        mapped = module.map_api_job({
+            "jobName": "Java",
+            "securityId": "sec value",
+            "lid": "lid-123",
+            "encryptJobId": "enc1",
+            "encryptBossId": "boss1",
+            "encryptBrandId": "brand1",
+        })
 
-        self.assertIn("security_id: j.securityId", module.FETCH_API_JS_TEMPLATE)
-        self.assertIn("lid: j.lid", module.FETCH_API_JS_TEMPLATE)
-        self.assertIn("encrypt_job_id: j.encryptJobId", module.FETCH_API_JS_TEMPLATE)
+        self.assertEqual(mapped["security_id"], "sec value")
+        self.assertEqual(mapped["lid"], "lid-123")
+        self.assertEqual(mapped["encrypt_job_id"], "enc1")
+        self.assertEqual(mapped["encrypt_boss_id"], "boss1")
+        self.assertEqual(mapped["encrypt_brand_id"], "brand1")
+        self.assertEqual(mapped["job_link"], "https://www.zhipin.com/job_detail/enc1.html")
+        self.assertEqual(mapped["company_link"], "https://www.zhipin.com/gongsi/brand1.html")
 
-    def test_dom_fallback_is_opt_in(self):
+    def test_map_api_job_maps_full_raw_fields(self):
         module = load_module()
+        mapped = module.map_api_job({
+            "jobName": "Python 工程师",
+            "salaryDesc": "20-40K·16薪",
+            "cityName": "上海",
+            "areaDistrict": "浦东新区",
+            "businessDistrict": "张江",
+            "jobExperience": "3-5年",
+            "jobDegree": "本科",
+            "brandName": "示例公司",
+            "brandScaleName": "1000-9999人",
+            "skills": ["Python", "Docker"],
+            "welfareList": ["五险一金", "带薪年假"],
+        })
 
-        self.assertFalse(module.should_use_dom_fallback([], allow_dom_fallback=False))
-        self.assertTrue(module.should_use_dom_fallback([], allow_dom_fallback=True))
-        self.assertFalse(module.should_use_dom_fallback([{"title": "Java"}], allow_dom_fallback=True))
+        self.assertEqual(mapped["salary"], "20-40K·16薪")
+        self.assertEqual(mapped["salary_source"], "api")
+        self.assertEqual(mapped["location"], "上海·浦东新区·张江")
+        self.assertEqual(mapped["tags"], "3-5年 | 本科")
+        self.assertEqual(mapped["skills"], "Python | Docker")
+        self.assertEqual(mapped["welfare"], "五险一金 | 带薪年假")
 
-    def test_api_job_parser_rejects_error_rows(self):
+        # 缺薪资时 salary_source 标记 api_empty；「不限」不进 tags
+        empty = module.map_api_job({"jobName": "X", "jobDegree": "不限"})
+        self.assertEqual(empty["salary_source"], "api_empty")
+        self.assertEqual(empty["tags"], "")
+
+    def test_map_api_jobs_skips_invalid_rows(self):
         module = load_module()
+        data = {
+            "code": 0,
+            "zpData": {"jobList": [
+                {"jobName": "Java", "salaryDesc": "20-40K"},
+                "not-a-dict",
+                None,
+            ]},
+        }
 
-        self.assertEqual(module.parse_api_jobs_eval_value(json.dumps([{"error": 403}])), [])
-        self.assertEqual(
-            module.parse_api_jobs_eval_value(json.dumps([{"title": "Java", "job_link": "https://example.com"}])),
-            [{"title": "Java", "job_link": "https://example.com"}],
-        )
+        jobs = module.map_api_jobs(data)
+
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0]["title"], "Java")
+        self.assertEqual(module.map_api_jobs(None), [])
+        self.assertEqual(module.map_api_jobs({"zpData": {}}), [])
 
     def test_login_probe_uses_one_budgeted_request(self):
         module = load_module()
-        cdp = mock.Mock()
-        cdp.eval_js.return_value = json.dumps({
-            "httpStatus": 200,
-            "body": json.dumps({
-                "code": 0,
-                "zpData": {"jobList": [{"jobName": "Java", "salaryDesc": "20-40K"}]},
-            }),
+        body = json.dumps({
+            "code": 0,
+            "zpData": {"jobList": [{"jobName": "Java", "salaryDesc": "20-40K"}]},
         })
+        cdp = FakeCaptureCDP(
+            pending_batches=[make_joblist_events("r1")],
+            responses={"r1": body},
+        )
         module._request_counter = 0
 
-        result = module.probe_login_state(cdp, "sid", query="Java", city_code="101020100")
+        result = module.probe_login_state(cdp, "fake-session", query="Java", city_code="101020100")
 
         self.assertIs(result.status, module.LoginProbeStatus.AVAILABLE)
-        self.assertEqual(cdp.eval_js.call_count, 1)
+        # 被动捕获：只导航一次，不发注入请求（无 Runtime.evaluate/XHR）
         self.assertEqual(module._request_counter, 1)
-        probe_js = cdp.eval_js.call_args.args[0]
-        self.assertIn("query=Java", probe_js)
-        self.assertIn("city=101020100", probe_js)
+        self.assertEqual(cdp.sent_methods.count("Page.navigate"), 1)
+        self.assertNotIn("Runtime.evaluate", cdp.sent_methods)
+
+    def test_login_probe_navigates_real_search_url(self):
+        module = load_module()
+        body = json.dumps({
+            "code": 0,
+            "zpData": {"jobList": [{"jobName": "Java", "salaryDesc": "20-40K"}]},
+        })
+        cdp = FakeCaptureCDP(
+            pending_batches=[make_joblist_events("r1")],
+            responses={"r1": body},
+        )
+
+        module.probe_login_state(cdp, "fake-session", query="AI Agent", city_code="101010100")
+
+        navigations = [p for m, p in cdp.sent if m == "Page.navigate"]
+        self.assertEqual(len(navigations), 1)
+        self.assertIn("query=AI+Agent", navigations[0]["url"])
+        self.assertIn("city=101010100", navigations[0]["url"])
+        self.assertIn("/web/geek/job", navigations[0]["url"])
+
+    def test_login_probe_reports_timeout_when_no_response(self):
+        module = load_module()
+        cdp = FakeCaptureCDP()  # 页面一直不发自带请求
+        module._request_counter = 0
+
+        result = module.probe_login_state(cdp, "fake-session", timeout=0.2)
+
+        self.assertIs(result.status, module.LoginProbeStatus.RESPONSE_ERROR)
+        self.assertTrue(result.retryable)
+        self.assertEqual(module._request_counter, 1)
+
+    def _run_scrape_list(self, module, cdp, output_path, pages=2):
+        """以 mock 掉节奏/连接的方式跑一遍 scrape_list，返回其结果。
+
+        module 必须与断言用的同一个 load_module() 实例（每次 load_module
+        返回新模块对象，异常类/全局计数器不能跨实例比较）。
+        """
+        module._request_counter = 0
+        with mock.patch.object(module, "CDPSession", lambda port=9222: cdp), \
+                mock.patch.object(module, "resolve_city", return_value=("上海", "101020100")), \
+                mock.patch("time.sleep", lambda s: None), \
+                mock.patch.object(module, "random", random.Random(7)):
+            return module.scrape_list(
+                "Java", "上海", pages, {}, output_path, cdp_port=9333,
+            )
+
+    def test_scrape_list_captures_pages_via_network_events(self):
+        module = load_module()
+        page1 = {"code": 0, "zpData": {"hasMore": True, "jobList": [
+            {"jobName": "A", "salaryDesc": "10K", "encryptJobId": "e1"},
+            {"jobName": "B", "salaryDesc": "20K", "encryptJobId": "e2"},
+        ]}}
+        page2 = {"code": 0, "zpData": {"hasMore": False, "jobList": [
+            {"jobName": "C", "salaryDesc": "30K", "encryptJobId": "e3"},
+            {"jobName": "D", "salaryDesc": "40K", "encryptJobId": "e4"},
+        ]}}
+        cdp = FakeCaptureCDP(
+            pending_batches=[make_joblist_events("r1"), make_joblist_events("r2")],
+            responses={"r1": json.dumps(page1), "r2": json.dumps(page2)},
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = str(pathlib.Path(tmp) / "jobs.json")
+            result = self._run_scrape_list(module, cdp, output_path, pages=2)
+
+        # 两页各 2 条，全部来自被动捕获（无注入 XHR：evaluate 只用于滚动）
+        self.assertEqual(result["total"], 4)
+        self.assertEqual([j["title"] for j in result["jobs"]], ["A", "B", "C", "D"])
+        self.assertTrue(all(j["salary_source"] == "api" for j in result["jobs"]))
+        self.assertEqual(module._request_counter, 2)
+        self.assertEqual(cdp.sent_methods.count("Page.navigate"), 1)
+        evaluate_bodies = [
+            p.get("expression", "") for m, p in cdp.sent if m == "Runtime.evaluate"
+        ]
+        self.assertTrue(evaluate_bodies)
+        self.assertFalse(any("XMLHttpRequest" in js for js in evaluate_bodies))
+
+    def test_scrape_list_gates_on_risk_control_first_response(self):
+        module = load_module()
+        restricted = {"code": 37, "message": "您的环境存在异常."}
+        cdp = FakeCaptureCDP(
+            pending_batches=[make_joblist_events("r1")],
+            responses={"r1": json.dumps(restricted)},
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = str(pathlib.Path(tmp) / "jobs.json")
+            with self.assertRaises(module.LoginGateError) as ctx:
+                self._run_scrape_list(module, cdp, output_path, pages=3)
+
+        self.assertIn("已停止抓取", str(ctx.exception))
+        self.assertIn("code: 37", str(ctx.exception))
+        # 风控在第一页就终止，不应继续滚动翻页
+        self.assertEqual(module._request_counter, 1)
 
     def test_wait_for_login_rotates_targets_and_backs_off(self):
         module = load_module()
@@ -1396,6 +1544,60 @@ class tempfile_profile:
 def fake_run(calls, *args, **kwargs):
     calls["run"].append(args[0])
     return type("Completed", (), {"stdout": "", "returncode": 0})()
+
+
+def make_joblist_events(request_id, url="https://www.zhipin.com/wapi/zpgeek/search/joblist.json?_=1"):
+    """合成一次已完成 joblist 请求的 Network 事件三件套。"""
+    return [
+        {"method": "Network.requestWillBeSent",
+         "params": {"requestId": request_id, "request": {"url": url}}},
+        {"method": "Network.responseReceived",
+         "params": {"requestId": request_id, "response": {"url": url, "status": 200}}},
+        {"method": "Network.loadingFinished",
+         "params": {"requestId": request_id}},
+    ]
+
+
+class FakeCaptureCDP:
+    """支持 Network 事件被动捕获的最小 CDP stub。
+
+    - events: 事件缓冲（与真实 CDPSession 同名同义）
+    - pending: 每次 drain_events 交付一批预置事件（模拟页面自身发请求）
+    - sent: 已发送命令 (method, params) 记录；sent_methods 为方法名视图
+    - send: getResponseBody 按 requestId 返回预置 body
+    """
+
+    def __init__(self, pending_batches=None, responses=None):
+        self.events = []
+        self.pending = list(pending_batches or [])
+        self.responses = dict(responses or {})
+        self.sent = []
+
+    @property
+    def sent_methods(self):
+        return [method for method, _ in self.sent]
+
+    def send(self, method, params=None, sid=None):
+        self.sent.append((method, params or {}))
+        if method == "Network.getResponseBody":
+            request_id = params["requestId"]
+            return {"result": {"body": self.responses[request_id], "base64Encoded": False}}
+        if method == "Target.createTarget":
+            return {"result": {"targetId": "fake-target"}}
+        if method == "Target.attachToTarget":
+            return {"result": {"sessionId": "fake-session"}}
+        return {"result": {}}
+
+    def drain_events(self, duration):
+        if self.pending:
+            self.events.extend(self.pending.pop(0))
+
+    def eval_js(self, js, sid):
+        self.sent.append(("Runtime.evaluate", {"expression": js}))
+        return None
+
+    def close(self):
+        pass
 
 
 def chrome_cmdline(cdp_port, user_data_dir):


### PR DESCRIPTION
Fixes #53
Related to #30

事情的起点是 #53 的诊断：页面自己发的搜索请求返回 code 0 和明文薪资，我们注入的同步 XHR 却拿到 code 37。这个 PR 把列表抓取和登录探测整个搬到「被动旁听」这一侧，不再向页面注入任何请求，只听页面自己发了什么。

动手当天就在本机验证了这个诊断。早上 `--setup-chrome` 的注入探测还被 37 拦着，改造后同一环境 `--check` 直接通过，抓两页 30 条全是明文薪资。顺带发现页面自己的请求其实是 POST + form body，而老代码注入的是 GET 拼 URL，这两个请求在服务端看来差别很大，被识别并不冤。

## 改动

抓取流程：导航到真实搜索页，通过 CDP `Network` 域等页面自己发出 joblist.json 请求，从响应里取数；翻页靠滚动触发页面自身的无限滚动加载，`hasMore` 为 false 就提前收工。字段映射从注入 JS 模板搬到了 Python（`map_api_job`），输出字段一个没变。

登录判定并进第一次真实搜索响应，正式抓取不再先发那个固定 Java/上海 的探测请求。分类逻辑还是 `classify_login_probe_response`，遇到风控照样立即停，提示文案和退出码跟原来一致。`--check` 和 `--setup-chrome` 的探测走同一套被动捕获，`wait_for_login` 的轮换退避逻辑没动。

## 一个坑

抓取标签页是后台打开的（不抢焦点），这种页面第一屏请求完全正常，但滚动后就是不肯触发加载，翻页静默失败。查下来是后台页真实的 `hidden / visibilityState=hidden / hasFocus=false` 状态挡住了 SPA 的 load-more。用 `Emulation.setFocusEmulationEnabled` 做焦点仿真解决：页面的视角里自己可见且有焦点，但窗口没有被激活，用户前台不受影响。

## 验证

单测从 92 增到 96 个，全绿（全 mock，不依赖真实 Chrome）。真机跑了 `--check`、`--smoke` 和两页抓取，30 条全部 `salary_source=api`，含 `boss_active_status`、`security_id` 等全字段。

## 兼容性

- 每页条数从 30 变为 15，这是页面自身行为决定的，抓同样数量岗位需要更多页（请求预算语义不变）
- 删除了 `FETCH_API_JS_TEMPLATE`、`build_login_probe_url`、`parse_api_jobs_eval_value`、`should_use_dom_fallback` 四个不再使用的函数
- 详情页路径、隔离 profile、输出格式、CLI 参数都没碰

方案来自 @xuan-nn 在 #53 的分析，这个 PR 只是把他的建议落成代码。