### PR TITLE
feat: add Codex Agent Skill manifest

### DIFF
--- a/.agents/skills/boss-zhipin-scraper/SKILL.md
+++ b/.agents/skills/boss-zhipin-scraper/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: boss-zhipin-scraper
+description: Search and analyze BOSS直聘 job listings through the repository's low-frequency Chrome CDP CLI. Use when the user asks to search zhipin.com jobs, inspect job details, export JSON/CSV, or summarize already-collected job data.
+---
+
+# BOSS直聘 job search
+
+Use the repository's existing CLI. Do not reimplement the BOSS request flow in a new script and do not add a second browser automation layer.
+
+## Before running commands
+
+1. Work from the repository root and confirm that `scripts/boss_cdp_raw.py` exists.
+2. Confirm Python 3.10+ and the dependencies from `requirements.txt` are available.
+3. Ask the user to log in manually in the dedicated CDP browser when needed. The skill must not request, store, or handle SMS codes, passwords, CAPTCHA answers, or cookies.
+4. Keep searches low frequency: start with one page and no more than three detail pages unless the user explicitly asks for a larger scope.
+
+## Standard workflow
+
+Run the environment check first:
+
+```text
+python scripts/boss_cdp_raw.py --check --cdp-port 9222
+```
+
+If the dedicated browser is not running, start it and wait for the user to finish login:
+
+```text
+python scripts/boss_cdp_raw.py --setup-chrome --cdp-port 9222
+```
+
+Then search a small result set:
+
+```text
+python scripts/boss_cdp_raw.py --keyword "AI Agent" --city 上海 --pages 1 --no-detail --output ~/.boss-zhipin-scraper/job-result/jobs.json
+```
+
+For selected jobs, fetch details with `--detail` and `--max-details 3`, or use the repository's documented two-stage workflow when available. Prefer JSON output for machine analysis and CSV only when the user asks for a spreadsheet-friendly export.
+
+After data already exists, use the repository summary script instead of rereading unrelated personal files:
+
+```text
+python scripts/job_summary.py --top 15
+```
+
+## Safety and stopping rules
+
+- Use only the user's dedicated CDP browser and the repository's isolated profile. Never copy the main browser profile by default.
+- Do not send messages, upload resumes, submit applications, or perform other external job-seeking actions. Those actions remain under the user's control.
+- Do not bypass CAPTCHA, spoof browser fingerprints, hide CDP, rotate proxies, or evade BOSS security controls.
+- If BOSS returns `code 37`, an abnormal-environment message, a CAPTCHA, or an `about:blank` redirect, stop immediately. Explain the observed condition and wait for the user; do not retry repeatedly.
+- Do not treat missing or DOM-obfuscated salary text as reliable plaintext. Preserve the CLI's `salary_source` field and report uncertainty.
+- Do not read or commit `job-data`, browser profiles, cookies, resumes, application materials, or other local personal data unless the user explicitly provides a specific file for analysis.
+
+## Reporting
+
+Report the exact command, output path, number of pages/details requested, and any skipped or failed step. Distinguish data returned by BOSS from analysis or recommendations inferred from the saved results.

--- a/.agents/skills/boss-zhipin-scraper/agents/openai.yaml
+++ b/.agents/skills/boss-zhipin-scraper/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BOSS直聘 Job Search"
+  short_description: "Search BOSS直聘 jobs with the repository CLI"
+  default_prompt: "Use $boss-zhipin-scraper to search a small set of BOSS直聘 jobs and summarize the results safely."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 未发布
 
 ### 新增
+- 新增符合 Agent Skills 标准的 Codex 入口 `.agents/skills/boss-zhipin-scraper/SKILL.md` 及静态格式测试；仅描述已有 CLI 和低频、安全使用边界，不包含岗位数据、Cookie 或其他本地敏感文件。（#62）
 - 详情/列表结果新增独立字段 `boss_active_status`（如「今日活跃」「在线」）：列表兼容 `activeTimeDesc` 与 `bossOnline`（仅在线时映射为「在线」）；详情页从招聘者卡片解析更细粒度状态并优先保留；JD 正文仍剔除该行，不混入描述
 - 新增 `--stop-chrome` 命令：抓取/分析完成后关闭 BOSS 专用 CDP Chrome（按 user-data-dir 精准匹配隔离 profile，不碰主 Chrome）；抓取命令新增 `--close-chrome` 选项，正常结束后自动收尾（默认关闭，异常退出不触发以保留登录态）。复用已有 `stop_cdp_chrome` 的安全匹配逻辑，补齐进程关闭/收尾链路的单元测试。（#26）
 - 城市码表外置为 `data/city_codes.json`（全量 300+ 城市，覆盖一二三四五线），新增 `--list-cities [关键词]` 命令查看支持的城市；`resolve_city` 查询链改为「本地静态码表 → 运行时拉 BOSS 接口 → 9 位裸码兜底」。城市码表打进 wheel，`pip install` 用户也可用。（#24）

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ hermes skills install https://raw.githubusercontent.com/eatmoreduck/boss-zhipin-
 
 > 注意：此方式依赖 hermes 进程能直接访问 GitHub，如果遇到超时或连接失败，请使用方式 1 或 2。
 
+### Codex / Agent Skills
+
+仓库同时提供符合 Agent Skills 标准的 Codex 入口：`.agents/skills/boss-zhipin-scraper/SKILL.md`。从仓库根目录打开项目时，Codex 可以发现该 Skill 并按其中的低频抓取、安全边界和用户确认规则调用已有 CLI；它不包含岗位结果、浏览器 profile、Cookie、简历或其他本地个人数据。
+
+Codex Skill 仍然使用仓库已有的 `scripts/boss_cdp_raw.py` 和 `scripts/job_summary.py`，不会替代或改变上面的 Hermes 安装方式。
+
 ### 验证安装
 
 ```bash

--- a/tests/test_codex_skill.py
+++ b/tests/test_codex_skill.py
@@ -1,0 +1,51 @@
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SKILL_PATH = ROOT / ".agents" / "skills" / "boss-zhipin-scraper" / "SKILL.md"
+OPENAI_METADATA_PATH = (
+    ROOT / ".agents" / "skills" / "boss-zhipin-scraper" / "agents" / "openai.yaml"
+)
+
+
+class CodexSkillTests(unittest.TestCase):
+    def test_skill_manifest_has_standard_front_matter(self):
+        text = SKILL_PATH.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("---\n"))
+        front_matter, _, instructions = text[4:].partition("\n---\n")
+        self.assertTrue(instructions.strip())
+
+        name = re.search(r"^name:\s*([^\n]+)$", front_matter, re.MULTILINE)
+        description = re.search(r"^description:\s*(.+)$", front_matter, re.MULTILINE)
+        self.assertIsNotNone(name)
+        self.assertEqual(name.group(1).strip(), "boss-zhipin-scraper")
+        self.assertIsNotNone(description)
+        self.assertGreater(len(description.group(1).strip()), 20)
+
+    def test_skill_describes_existing_cli_and_user_controlled_boundaries(self):
+        text = SKILL_PATH.read_text(encoding="utf-8")
+
+        for expected in (
+            "scripts/boss_cdp_raw.py",
+            "scripts/job_summary.py",
+            "--check",
+            "--setup-chrome",
+            "code 37",
+            "SMS",
+            "Do not send messages",
+        ):
+            self.assertIn(expected, text)
+
+    def test_codex_metadata_is_present_and_does_not_reference_local_data(self):
+        text = OPENAI_METADATA_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("display_name:", text)
+        self.assertIn("default_prompt:", text)
+        self.assertNotIn("job-data", text)
+        self.assertNotIn("Cookies", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

- 新增标准 Agent Skill 入口 `.agents/skills/boss-zhipin-scraper/SKILL.md`，使用 `name`/`description` front matter。
- 新增可选的 Codex 界面元数据 `.agents/skills/boss-zhipin-scraper/agents/openai.yaml`。
- Skill 复用已有 `scripts/boss_cdp_raw.py` 和 `scripts/job_summary.py`，明确低频抓取、`code 37` 停止、用户控制登录/申请动作以及敏感数据不入库边界。
- 保留原有 Hermes `SKILL.md` 和 CLI，不引入数据库、Web UI 或外部服务。
- 增加 3 项静态格式/边界测试，并在 README/CHANGELOG 中说明入口。

## 数据安全

本 PR 未添加 `job-data`、浏览器 profile、Cookie、简历或其他本地个人文件；本地未跟踪研究数据也未被提交。

Related to #62

## 验证

- `python -m unittest tests.test_codex_skill tests.test_chrome_setup.VersionConsistencyTests`（5 项通过）
- `git diff --check`（通过）

说明：完整旧 `tests.test_chrome_setup` 在当前 Windows 基线仍有与本 PR 无关的 GBK/模拟进程输出失败，运行时修复已单独放在 #30 PR。