### PR TITLE
feat: 新增桌面图形界面，支持多关键词与自定义结果目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ htmlcov/
 
 # Project-generated local files
 docs/
+job-result/
 
 # Local skill tooling config (baoyu-image-gen etc.)
 .baoyu-skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,13 @@
 ```
 scripts/boss_cdp_raw.py   # 核心：抓取 + CLI 主入口（长单文件，行数以实际为准）
 scripts/job_summary.py    # 抓取结果 → Markdown 求职分析摘要
+scripts/boss_gui.py       # 桌面图形界面（薄 UI 壳：子进程调 boss_cdp_raw.py，exit 0 后可自动接跑 job_summary.py；不含抓取逻辑）
 data/city_codes.json      # 全量城市码表（300+ 城市，外置；见下）
+job-result/               # 抓取结果默认目录（.gitignore 忽略的本地产物；可用 $BOSS_RESULT_DIR 覆盖）
 tests/test_chrome_setup.py    # unittest，全 mock，不依赖真实 Chrome/网络
 tests/test_job_summary.py     # 摘要测试
-pyproject.toml            # hatchling 打包；入口 boss-scraper / boss-summary
+tests/test_gui_chain.py       # GUI 命令行拼装 + 自动接跑摘要判定
+pyproject.toml            # hatchling 打包；入口 boss-scraper / boss-summary / boss-gui
 requirements.txt          # 仅 requests + websocket-client
 SKILL.md / README(.en).md / CHANGELOG.md / CONTRIBUTING.md
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@
 - 删除死代码：`FETCH_API_JS_TEMPLATE`、`build_login_probe_url`、`parse_api_jobs_eval_value`、`should_use_dom_fallback`；`CDPSession` 新增事件缓冲与 `drain_events`；测试从 92 增至 96 个
 
 ### 新增
+- 结果目录支持 `$BOSS_RESULT_DIR` 环境变量覆盖（默认仍为 `~/.boss-zhipin-scraper/job-result`），GUI 增加「结果目录」自定义输入框与「浏览...」按钮，抓取/摘要均按自定义目录显式落盘；GUI 支持多关键词（英文/中文逗号、分号或换行分隔，逐个抓取并用 `--merge` 自动合并去重，最后对合并结果生成一份摘要）
+- 新增桌面图形界面 `scripts/boss_gui.py`（tkinter，零额外依赖）：可视化配置关键词 / 城市 / 页数 / CDP 端口 / CSV / 详情页 / 分析报告，一键运行「环境检查」「启动 Chrome」「Smoke 测试」「开始抓取」「生成摘要」「关闭 Chrome」；勾选「抓取完成后自动生成摘要」后，抓取正常结束（exit 0）会自动接跑 `scripts/job_summary.py`。GUI 默认不抓详情页避免长时间运行，并新增 `boss-gui` 命令入口
+
 - 详情/列表结果新增独立字段 `boss_active_status`（如「今日活跃」「在线」）：列表兼容 `activeTimeDesc` 与 `bossOnline`（仅在线时映射为「在线」）；详情页从招聘者卡片解析更细粒度状态并优先保留；JD 正文仍剔除该行，不混入描述
 - 新增 `--stop-chrome` 命令：抓取/分析完成后关闭 BOSS 专用 CDP Chrome（按 user-data-dir 精准匹配隔离 profile，不碰主 Chrome）；抓取命令新增 `--close-chrome` 选项，正常结束后自动收尾（默认关闭，异常退出不触发以保留登录态）。复用已有 `stop_cdp_chrome` 的安全匹配逻辑，补齐进程关闭/收尾链路的单元测试。（#26）
 - 城市码表外置为 `data/city_codes.json`（全量 300+ 城市，覆盖一二三四五线），新增 `--list-cities [关键词]` 命令查看支持的城市；`resolve_city` 查询链改为「本地静态码表 → 运行时拉 BOSS 接口 → 9 位裸码兜底」。城市码表打进 wheel，`pip install` 用户也可用。（#24）
 
 ### 修复
+- 修复 GUI 任务收尾事件解包错误：此前 smoke 测试 / 抓取结束后轮询器崩溃，导致「完成」消息不显示、状态卡在「运行中」、自动摘要不触发，且后续按钮被误判为「已有任务在运行」
 - Windows 兼容：`main()` 入口将 stdout/stderr 重配为 UTF-8，修复 Windows GBK 控制台遇到 emoji（✅❌⚠️ 等）输出直接 `UnicodeEncodeError` 崩溃的问题（实测此前 73 个单测中 8 个因此失败）
 - JSON 落盘改为原子写入（临时文件 + `os.replace`）：进程中断不再留下半截 JSON 覆盖旧数据；`flush_jobs`、详情页写入与 `--merge` 详情落盘统一走 `_atomic_write_json`
 - `--check` 的 CDP 连通检查不再把任意 CDP 服务误报为「Chrome」，改为输出实际服务标识

--- a/README.en.md
+++ b/README.en.md
@@ -150,6 +150,24 @@ python3 scripts/boss_cdp_raw.py --keyword "AI Agent" --city 上海 --pages 3 --f
 python3 scripts/job_summary.py --top 15
 ```
 
+## Desktop GUI
+
+Prefer clicking over typing commands? A small tkinter desktop GUI ships with the repo (zero extra dependencies):
+
+```bash
+python3 scripts/boss_gui.py
+# or after installing the package
+uv run boss-gui
+```
+
+Fill in keyword / city / pages / CDP port, tick CSV output, detail pages and the analysis report, then run one-click actions: Environment check, Launch Chrome, Smoke test, Start scrape, Generate summary, Close Chrome. When **“Auto-generate summary after scrape”** is checked, a successful scrape (exit 0) automatically runs `scripts/job_summary.py` next — no need to launch the second file by hand. Output streams into the log pane in real time and can be stopped anytime.
+
+Note: the GUI does **not** scrape detail pages by default (fast); tick “Scrape detail pages” when you need JDs. First-time users should click “Launch Chrome” and log in to zhipin.com in the dedicated browser that pops up.
+
+The keyword field accepts multiple keywords separated by commas (English or Chinese), semicolons, or newlines. The GUI scrapes them one by one, merges the results with `--merge` (deduped by `job_id`), and generates one summary for the combined result.
+
+The result directory is customizable in the GUI (with a “Browse…” button), defaulting to the directory set by `$BOSS_RESULT_DIR` (or `~/.boss-zhipin-scraper/job-result` when unset).
+
 ## Parameters
 
 | Parameter | Description |
@@ -173,8 +191,8 @@ python3 scripts/job_summary.py --top 15
 | `--login-timeout` | Seconds to wait for login under `--setup-chrome` (default 300) |
 | `--stop-chrome` | Close the dedicated BOSS CDP Chrome (matched precisely by the isolated profile; never touches your main Chrome) |
 | `--close-chrome` | Auto-close the dedicated Chrome after a scrape finishes normally (off by default; not triggered on errors, so the login state is kept) |
-| `--output` | List output path (default `~/.boss-zhipin-scraper/job-result/`) |
-| `--detail-output` | Detail output path (default `~/.boss-zhipin-scraper/job-result/`) |
+| `--output` | List output path (default `$BOSS_RESULT_DIR`, falling back to `~/.boss-zhipin-scraper/job-result/`) |
+| `--detail-output` | Detail output path (default `$BOSS_RESULT_DIR`, falling back to `~/.boss-zhipin-scraper/job-result/`) |
 | `--cdp-port` | CDP port (default 9222) |
 | `--scale/--salary/--experience/--degree` | Filters |
 
@@ -218,6 +236,7 @@ boss-zhipin-scraper/
 │   └── city_codes.json   # Full city-code map
 ├── scripts/
 │   ├── boss_cdp_raw.py   # Main scraping script
+│   ├── boss_gui.py       # Desktop GUI (thin shell around boss_cdp_raw.py)
 │   └── job_summary.py    # Post-scrape summary + prompt
 └── requirements.txt
 ```
@@ -246,7 +265,7 @@ For detail pages, the scraper only extracts a section containing the job-descrip
 
 Without an explicit `--output` or `--detail-output`, scraping results are saved under:
 
-- `~/.boss-zhipin-scraper/job-result`
+- `~/.boss-zhipin-scraper/job-result` (override with the `BOSS_RESULT_DIR` environment variable, e.g. `D:\projects\boss-zhipin-scraper\job-result`)
 
 On first use you must log in to BOSS Zhipin manually inside this dedicated Chrome. `--setup-chrome` waits for the login to finish and uses the search API to confirm it can get plaintext `salaryDesc` before returning. The session is stored inside the dedicated profile and survives reboots; re-running `--setup-chrome` does not wipe it and does not affect your main Chrome, Gmail, GitHub, or other accounts.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,24 @@ python3 scripts/boss_cdp_raw.py --keyword "AI Agent" --city 上海 --pages 3 --f
 python3 scripts/job_summary.py --top 15
 ```
 
+## 图形界面（桌面 GUI）
+
+不想敲命令行时，可以启动内置的 tkinter 桌面界面（零额外依赖）：
+
+```bash
+python3 scripts/boss_gui.py
+# 或打包安装后
+uv run boss-gui
+```
+
+界面里可以填写关键词 / 城市 / 页数 / CDP 端口、勾选 CSV 输出、详情页与分析报告，并一键运行「环境检查」「启动 Chrome」「Smoke 测试」「开始抓取」「生成摘要」「关闭 Chrome」。勾选 **「抓取完成后自动生成摘要」** 后，抓取正常结束（exit 0）会自动接跑 `scripts/job_summary.py`，不用再手动运行第二个文件；输出面板实时显示日志，可随时「停止」。
+
+注意：GUI 默认**不抓详情页**（速度快），需要 JD 时勾选「抓详情页」。首次使用请先「启动 Chrome」并在弹出的专用浏览器中登录 zhipin.com。
+
+关键词支持填多个（用英文/中文逗号、分号或换行分隔），GUI 会逐个抓取并用 `--merge` 自动合并去重，最后对合并结果生成一份摘要。
+
+结果目录可以在界面中自定义（含「浏览...」按钮），默认取 `$BOSS_RESULT_DIR` 指定的目录（未设置时为 `~/.boss-zhipin-scraper/job-result`）。
+
 ## 参数
 
 | 参数 | 说明 |
@@ -175,8 +193,8 @@ python3 scripts/job_summary.py --top 15
 | `--login-timeout` | `--setup-chrome` 等待登录完成的秒数（默认 300） |
 | `--stop-chrome` | 关闭 BOSS 专用 CDP Chrome（按隔离 profile 精准匹配，不碰主 Chrome） |
 | `--close-chrome` | 抓取正常结束后自动关闭专用 Chrome（默认不关；异常退出不触发，保留登录态） |
-| `--output` | 列表输出路径（默认 `~/.boss-zhipin-scraper/job-result/`） |
-| `--detail-output` | 详情输出路径（默认 `~/.boss-zhipin-scraper/job-result/`） |
+| `--output` | 列表输出路径（默认 `$BOSS_RESULT_DIR`，未设置时为 `~/.boss-zhipin-scraper/job-result/`） |
+| `--detail-output` | 详情输出路径（默认 `$BOSS_RESULT_DIR`，未设置时为 `~/.boss-zhipin-scraper/job-result/`） |
 | `--cdp-port` | CDP 端口（默认 9222） |
 | `--scale/--salary/--experience/--degree` | 筛选条件 |
 
@@ -219,6 +237,7 @@ boss-zhipin-scraper/
 │   └── city_codes.json   # 全量城市码表
 ├── scripts/
 │   ├── boss_cdp_raw.py   # 抓取主脚本
+│   ├── boss_gui.py       # 桌面图形界面（薄壳，调 boss_cdp_raw.py）
 │   └── job_summary.py    # 抓取后摘要 + 提示词
 └── requirements.txt
 ```
@@ -247,7 +266,7 @@ boss-zhipin-scraper/
 
 未显式指定 `--output` 或 `--detail-output` 时，抓取结果默认保存到：
 
-- `~/.boss-zhipin-scraper/job-result`
+- `~/.boss-zhipin-scraper/job-result`（可用环境变量 `BOSS_RESULT_DIR` 覆盖，例如 `D:\projects\boss-zhipin-scraper\job-result`）
 
 首次使用需要在这个专用 Chrome 中手动登录 BOSS直聘。`--setup-chrome` 会等待登录完成，并用搜索接口确认能拿到明文 `salaryDesc` 后再返回。登录态保存在专用 profile 内，重启机器后仍然保留；重复运行 `--setup-chrome` 不会清空它，也不会影响主 Chrome、Gmail、GitHub 等账号。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ all = [
 # 安装后顶层包名为 scripts，故入口是 scripts.boss_cdp_raw:main
 boss-scraper = "scripts.boss_cdp_raw:main"
 boss-summary = "scripts.job_summary:main"
+boss-gui = "scripts.boss_gui:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -110,7 +110,17 @@ DEFAULT_CHROME_PATH = get_default_chrome_path()
 DEFAULT_PROFILE_DIR = get_default_profile_dir()
 
 DEFAULT_CDP_DATA_DIR = os.path.expanduser("~/.boss-zhipin-scraper/chrome-profile")
-DEFAULT_RESULT_DIR = os.path.expanduser("~/.boss-zhipin-scraper/job-result")
+
+
+def _resolve_result_dir():
+    """结果目录：优先 $BOSS_RESULT_DIR，默认 ~/.boss-zhipin-scraper/job-result。"""
+    configured = os.environ.get("BOSS_RESULT_DIR")
+    if configured:
+        return os.path.expanduser(configured)
+    return os.path.expanduser("~/.boss-zhipin-scraper/job-result")
+
+
+DEFAULT_RESULT_DIR = _resolve_result_dir()
 DEFAULT_CITY_INPUT = "上海"
 LOGIN_PROBE_QUERY = "Java"
 LOGIN_PROBE_CITY = "101020100"

--- a/scripts/boss_gui.py
+++ b/scripts/boss_gui.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""BOSS直聘 抓取 + 摘要 桌面图形界面（tkinter，零额外依赖）。
+
+薄 UI 壳：只负责把界面参数拼成命令行、以子进程调用
+``scripts/boss_cdp_raw.py``，抓取正常结束（exit 0）后按勾选自动接跑
+``scripts/job_summary.py``。不包含任何抓取/分析逻辑（见 AGENTS.md
+单文件原则：核心逻辑仍在 boss_cdp_raw.py）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import queue
+import re
+import shlex
+import subprocess
+import sys
+import threading
+import tkinter as tk
+from datetime import datetime
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+
+try:
+    from scripts import boss_cdp_raw as boss
+except ImportError:  # 直接以脚本方式运行时（工作目录=仓库根目录）
+    import boss_cdp_raw as boss
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CORE_SCRIPT = os.path.join(SCRIPT_DIR, "boss_cdp_raw.py")
+SUMMARY_SCRIPT = os.path.join(SCRIPT_DIR, "job_summary.py")
+CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+DEFAULT_RESULT_DIR = os.path.expanduser(boss.DEFAULT_RESULT_DIR)
+
+
+# ---------------------------------------------------------------- 命令拼装
+
+def build_scrape_args(
+    keyword: str,
+    city: str,
+    pages: int,
+    cdp_port: int = boss.DEFAULT_CDP_PORT,
+    fmt: str = "json",
+    detail: bool = False,
+    analysis: bool = False,
+    output: str | None = None,
+    detail_output: str | None = None,
+    merge: str | None = None,
+) -> list[str]:
+    """拼 boss_cdp_raw.py 的抓取命令（默认 json、不抓详情，保证尽快跑完）。"""
+    args = [
+        sys.executable,
+        CORE_SCRIPT,
+        "--keyword",
+        keyword,
+        "--city",
+        city,
+        "--pages",
+        str(pages),
+        "--cdp-port",
+        str(cdp_port),
+    ]
+    if fmt and fmt.lower() == "csv":
+        args += ["--format", "csv"]
+    args.append("--detail" if detail else "--no-detail")
+    if analysis:
+        args.append("--analysis")
+    if output:
+        args += ["--output", output]
+    if detail_output:
+        args += ["--detail-output", detail_output]
+    if merge:
+        args += ["--merge", merge]
+    return args
+
+
+def split_keywords(raw: str) -> list[str]:
+    """把用户输入拆成多个关键词：支持英文/中文逗号、分号、换行。"""
+    parts = re.split(r"[,，;；\n\r]+", raw or "")
+    return [part.strip() for part in parts if part.strip()]
+
+
+def build_summary_args(
+    top: int = 10,
+    input_path: str | None = None,
+    result_dir: str | None = None,
+) -> list[str]:
+    """拼 job_summary.py 的摘要命令（默认读最新结果文件并自动匹配详情）。"""
+    args = [sys.executable, SUMMARY_SCRIPT, "--top", str(top)]
+    if input_path:
+        args += ["--input", input_path]
+    if result_dir:
+        args += ["--result-dir", result_dir]
+    return args
+
+
+def build_multi_keyword_steps(
+    keywords: list[str],
+    city: str,
+    pages: int,
+    cdp_port: int = boss.DEFAULT_CDP_PORT,
+    fmt: str = "json",
+    detail: bool = False,
+    analysis: bool = False,
+    result_dir: str | None = None,
+    timestamp: str | None = None,
+):
+    """多关键词：逐个抓取，后续关键词用 --merge 合并进同一个结果文件。
+
+    返回 (steps, final_path, part_paths)：
+    - steps: [(命令, 显示名), ...]
+    - final_path: 最终结果文件（单个/多个关键词都显式指定，摘要直接读它）
+    - part_paths: 合并过程的临时分片文件（全部成功后清理）
+    """
+    result_dir = result_dir or DEFAULT_RESULT_DIR
+    ts = timestamp or datetime.now().strftime("%Y%m%d_%H%M")
+    if len(keywords) == 1:
+        output = os.path.join(result_dir, f"boss_jobs_{ts}.json")
+        detail_output = os.path.join(result_dir, f"boss_details_{ts}.json") if detail else None
+        args = build_scrape_args(
+            keywords[0], city, pages, cdp_port, fmt, detail, analysis,
+            output=output, detail_output=detail_output,
+        )
+        return [(args, f"抓取 [{keywords[0]}]")], output, []
+
+    final_path = os.path.join(result_dir, f"boss_jobs_{ts}_multi.json")
+    steps = []
+    part_paths = []
+    previous = final_path
+    for index, keyword in enumerate(keywords):
+        if index == 0:
+            detail_output = os.path.join(result_dir, f"boss_details_{ts}_multi.json") if detail else None
+            args = build_scrape_args(
+                keyword, city, pages, cdp_port, fmt, detail, analysis,
+                output=final_path, detail_output=detail_output,
+            )
+            steps.append((args, f"抓取 [{keyword}]"))
+        else:
+            part = os.path.join(result_dir, f"boss_jobs_{ts}_multi.part{index}.json")
+            part_paths.append(part)
+            detail_output = os.path.join(result_dir, f"boss_details_{ts}_multi.part{index}.json") if detail else None
+            args = build_scrape_args(
+                keyword, city, pages, cdp_port, fmt, detail, analysis,
+                output=part, detail_output=detail_output, merge=previous,
+            )
+            steps.append((args, f"抓取并合并 [{keyword}]"))
+            previous = part
+    return steps, final_path, part_paths
+
+
+def build_check_args(cdp_port: int) -> list[str]:
+    return [sys.executable, CORE_SCRIPT, "--check", "--cdp-port", str(cdp_port)]
+
+
+def build_setup_chrome_args(cdp_port: int) -> list[str]:
+    # --no-wait-login：GUI 里启动后立即返回，登录由用户在弹出的 Chrome 里完成
+    return [
+        sys.executable,
+        CORE_SCRIPT,
+        "--setup-chrome",
+        "--cdp-port",
+        str(cdp_port),
+        "--no-wait-login",
+    ]
+
+
+def build_smoke_args(cdp_port: int) -> list[str]:
+    return [sys.executable, CORE_SCRIPT, "--smoke-test", "--cdp-port", str(cdp_port)]
+
+
+def build_stop_chrome_args(cdp_port: int) -> list[str]:
+    return [sys.executable, CORE_SCRIPT, "--stop-chrome", "--cdp-port", str(cdp_port)]
+
+
+def should_auto_summary(exit_code: int) -> bool:
+    """只在抓取成功退出时自动接跑摘要（与 --close-chrome 的成功路径惯例一致）。"""
+    return exit_code == 0
+
+
+def _quote(arg: str) -> str:
+    return shlex.quote(arg)
+
+
+# ---------------------------------------------------------------- 界面
+
+class BossGui:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.proc: subprocess.Popen | None = None
+        self.queue: queue.Queue = queue.Queue()
+        self.busy = False
+        self._scrape_steps: list = []
+        self._scrape_index = 0
+        self._scrape_final: str | None = None
+        self._scrape_parts: list[str] = []
+        self._build_ui()
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+        self._poll_queue()
+
+    # ---- 控件 ----
+    def _build_ui(self):
+        self.root.title(f"BOSS直聘 抓取 + 摘要 v{boss.__version__}")
+        self.root.geometry("880x660")
+        self.root.minsize(720, 520)
+
+        params = ttk.LabelFrame(self.root, text="抓取参数")
+        params.pack(fill="x", padx=10, pady=(10, 4))
+
+        self.keyword_var = tk.StringVar(value="AI Agent")
+        self.city_var = tk.StringVar(value="上海")
+        self.pages_var = tk.IntVar(value=3)
+        self.port_var = tk.IntVar(value=boss.DEFAULT_CDP_PORT)
+        self.fmt_var = tk.StringVar(value="json")
+        self.detail_var = tk.BooleanVar(value=False)
+        self.analysis_var = tk.BooleanVar(value=False)
+        self.auto_summary_var = tk.BooleanVar(value=True)
+        self.top_var = tk.IntVar(value=10)
+        self.result_dir_var = tk.StringVar(value=DEFAULT_RESULT_DIR)
+
+        row1 = ttk.Frame(params)
+        row1.pack(fill="x", padx=8, pady=6)
+        ttk.Label(row1, text="关键词（多个用 , 或 ; 分隔）").pack(side="left")
+        ttk.Entry(row1, textvariable=self.keyword_var, width=26).pack(side="left", padx=(4, 12))
+        ttk.Label(row1, text="城市").pack(side="left")
+        ttk.Entry(row1, textvariable=self.city_var, width=12).pack(side="left", padx=(4, 12))
+        ttk.Label(row1, text="页数 (1-10)").pack(side="left")
+        ttk.Spinbox(row1, from_=1, to=10, textvariable=self.pages_var, width=5).pack(side="left", padx=(4, 12))
+        ttk.Label(row1, text="CDP 端口").pack(side="left")
+        ttk.Entry(row1, textvariable=self.port_var, width=7).pack(side="left", padx=(4, 4))
+
+        row2 = ttk.Frame(params)
+        row2.pack(fill="x", padx=8, pady=(0, 6))
+        ttk.Label(row2, text="输出格式").pack(side="left")
+        ttk.Combobox(
+            row2, textvariable=self.fmt_var, values=("json", "csv"),
+            state="readonly", width=6,
+        ).pack(side="left", padx=(4, 14))
+        ttk.Checkbutton(row2, text="抓详情页 (JD，较慢)", variable=self.detail_var).pack(side="left")
+        ttk.Checkbutton(row2, text="分析报告", variable=self.analysis_var).pack(side="left", padx=(10, 0))
+        ttk.Checkbutton(
+            row2, text="抓取完成后自动生成摘要", variable=self.auto_summary_var,
+        ).pack(side="left", padx=(16, 10))
+        ttk.Label(row2, text="Top").pack(side="left")
+        ttk.Spinbox(row2, from_=1, to=50, textvariable=self.top_var, width=4).pack(side="left", padx=(4, 0))
+
+        row3 = ttk.Frame(params)
+        row3.pack(fill="x", padx=8, pady=(0, 6))
+        ttk.Label(row3, text="结果目录").pack(side="left")
+        ttk.Entry(row3, textvariable=self.result_dir_var, width=58).pack(side="left", padx=(4, 6))
+        ttk.Button(row3, text="浏览...", command=self._browse_result_dir).pack(side="left")
+
+        actions = ttk.LabelFrame(self.root, text="操作")
+        actions.pack(fill="x", padx=10, pady=4)
+        buttons = ttk.Frame(actions)
+        buttons.pack(fill="x", padx=8, pady=6)
+        for text, command in (
+            ("环境检查", self._run_check),
+            ("启动 Chrome", self._run_setup_chrome),
+            ("Smoke 测试", self._run_smoke),
+            ("开始抓取", self._run_scrape),
+            ("生成摘要", self._run_summary),
+            ("关闭 Chrome", self._run_stop_chrome),
+            ("停止", self._stop),
+        ):
+            ttk.Button(buttons, text=text, command=command).pack(side="left", padx=4)
+
+        output_frame = ttk.LabelFrame(self.root, text="输出")
+        output_frame.pack(fill="both", expand=True, padx=10, pady=4)
+        self.output = scrolledtext.ScrolledText(
+            output_frame, wrap="word", state="normal", font=("Consolas", 10),
+        )
+        self.output.pack(fill="both", expand=True, padx=6, pady=6)
+        self.output.tag_configure("ok", foreground="#1a7f37")
+        self.output.tag_configure("err", foreground="#b42318")
+        self.output.tag_configure("cmd", foreground="#0b57d0")
+
+        self.status_var = tk.StringVar(value="就绪")
+        self.status = ttk.Label(self.root, textvariable=self.status_var, anchor="w")
+        self.status.pack(fill="x", padx=10, pady=(0, 6))
+
+    # ---- 公共 ----
+    def _start(self, command: list[str], label: str, chain: bool = False):
+        if self.proc and self.proc.poll() is None:
+            messagebox.showwarning("任务运行中", "已有任务在运行，请先点「停止」。")
+            return
+        self._write_line(f"\n$ {' '.join(_quote(arg) for arg in command)}\n", "cmd")
+        env = os.environ.copy()
+        env.setdefault("PYTHONIOENCODING", "utf-8")
+        env["PYTHONUNBUFFERED"] = "1"
+        try:
+            proc = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                env=env,
+                creationflags=CREATE_NO_WINDOW,
+            )
+        except OSError as exc:
+            messagebox.showerror("启动失败", str(exc))
+            return
+        self.proc = proc
+        self._set_busy(label)
+        threading.Thread(target=self._pump, args=(proc, label, chain), daemon=True).start()
+
+    def _pump(self, proc: subprocess.Popen, label: str, chain: bool):
+        try:
+            for line in proc.stdout:
+                self.queue.put(("out", line))
+        except (OSError, ValueError):
+            pass
+        finally:
+            code = proc.wait()
+            self.queue.put(("done", code, label, chain))
+
+    def _poll_queue(self):
+        try:
+            while True:
+                item = self.queue.get_nowait()
+                kind = item[0]
+                if kind == "out":
+                    self._write(item[1])
+                elif kind == "done":
+                    self._handle_done(item[1], item[2], item[3])
+        except queue.Empty:
+            pass
+        self.root.after(50, self._poll_queue)
+
+    def _handle_done(self, code: int, label: str, chain: bool):
+        self.proc = None
+        self._set_busy(None)
+        ok = code == 0
+        self._write_line(
+            f"\n[完成] {label} 退出码 {code}（{'成功' if ok else '失败'}）",
+            "ok" if ok else "err",
+        )
+        if chain:
+            if should_auto_summary(code) and self._scrape_index < len(self._scrape_steps):
+                self._write_line(
+                    f"\n继续下一个关键词（{self._scrape_index + 1}/{len(self._scrape_steps)}）...",
+                    "ok",
+                )
+                self._next_scrape_step()
+                return
+            if should_auto_summary(code):
+                self._finalize_multi()
+                self._write_line("抓取成功，自动运行摘要脚本 job_summary.py ...", "ok")
+                self._start(
+                    build_summary_args(
+                        self.top_var.get(),
+                        input_path=self._scrape_final,
+                        result_dir=self.result_dir_var.get().strip() or None,
+                    ),
+                    "摘要生成",
+                    chain=False,
+                )
+            else:
+                self._write_line(
+                    "抓取未正常结束，跳过摘要（登录失败/风控/异常退出时不接跑摘要）。",
+                    "err",
+                )
+
+    def _stop(self):
+        proc = self.proc
+        if not proc or proc.poll() is not None:
+            self._write_line("\n当前没有运行中的任务。")
+            return
+        self._write_line("\n[停止] 正在终止当前任务...", "err")
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    def _on_close(self):
+        if self.proc and self.proc.poll() is None:
+            if messagebox.askyesno("任务运行中", "当前任务尚未结束，关闭窗口将终止它。确定退出？"):
+                self._stop()
+        self.root.destroy()
+
+    # ---- 按钮动作 ----
+    def _run_check(self):
+        self._start(build_check_args(self._port()), "环境检查", chain=False)
+
+    def _run_setup_chrome(self):
+        self._write_line("\n提示：启动后请在弹出的专用 Chrome 中登录 zhipin.com（若已登录则无需操作）。\n")
+        self._start(build_setup_chrome_args(self._port()), "启动 Chrome", chain=False)
+
+    def _run_smoke(self):
+        self._start(build_smoke_args(self._port()), "Smoke 测试", chain=False)
+
+    def _run_scrape(self):
+        keywords = split_keywords(self.keyword_var.get())
+        if not keywords:
+            messagebox.showerror("参数错误", "请填写至少一个关键词。")
+            return
+        result_dir = self.result_dir_var.get().strip() or DEFAULT_RESULT_DIR
+        try:
+            os.makedirs(result_dir, exist_ok=True)
+        except OSError as exc:
+            messagebox.showerror("目录不可用", f"无法创建结果目录：{exc}")
+            return
+        try:
+            pages = int(self.pages_var.get())
+            port = int(self.port_var.get())
+        except (TypeError, ValueError):
+            messagebox.showerror("参数错误", "页数和端口必须是整数。")
+            return
+        if not 1 <= pages <= 10:
+            messagebox.showerror("参数错误", "页数必须在 1-10 之间。")
+            return
+        steps, final_path, part_paths = build_multi_keyword_steps(
+            keywords=keywords,
+            city=self.city_var.get().strip() or "上海",
+            pages=pages,
+            cdp_port=port,
+            fmt=self.fmt_var.get(),
+            detail=self.detail_var.get(),
+            analysis=self.analysis_var.get(),
+            result_dir=result_dir,
+        )
+        if len(keywords) > 1:
+            self._write_line(
+                f"\n多关键词模式：{len(keywords)} 个关键词将逐个抓取并自动合并去重。\n",
+                "cmd",
+            )
+        self._scrape_steps = steps
+        self._scrape_index = 0
+        self._scrape_final = final_path
+        self._scrape_parts = part_paths
+        self._next_scrape_step()
+
+    def _next_scrape_step(self):
+        if not self._scrape_steps or self._scrape_index >= len(self._scrape_steps):
+            return
+        command, label = self._scrape_steps[self._scrape_index]
+        self._scrape_index += 1
+        self._start(command, label, chain=True)
+
+    def _finalize_multi(self):
+        """把最后一个合并分片改名为最终结果文件，并清理中间分片。"""
+        if not self._scrape_parts:
+            return
+        last = self._scrape_parts[-1]
+        if os.path.isfile(last):
+            os.replace(last, self._scrape_final)
+        for part in self._scrape_parts:
+            if part != last and os.path.isfile(part):
+                try:
+                    os.remove(part)
+                except OSError:
+                    pass
+        self._scrape_parts = []
+
+    def _run_summary(self):
+        self._start(
+            build_summary_args(
+                self.top_var.get(),
+                result_dir=self.result_dir_var.get().strip() or None,
+            ),
+            "摘要生成",
+            chain=False,
+        )
+
+    def _run_stop_chrome(self):
+        self._start(build_stop_chrome_args(self._port()), "关闭 Chrome", chain=False)
+
+    # ---- 小工具 ----
+    def _browse_result_dir(self):
+        selected = filedialog.askdirectory(
+            title="选择结果保存目录",
+            initialdir=self.result_dir_var.get().strip() or DEFAULT_RESULT_DIR,
+        )
+        if selected:
+            self.result_dir_var.set(selected)
+
+    def _port(self) -> int:
+        try:
+            return int(self.port_var.get())
+        except (TypeError, ValueError):
+            return boss.DEFAULT_CDP_PORT
+
+    def _set_busy(self, label):
+        self.busy = label is not None
+        self.status_var.set("运行中: " + label if label else "就绪")
+
+    def _write(self, text: str):
+        self.output.insert(tk.END, text)
+        self.output.see(tk.END)
+
+    def _write_line(self, text: str, tag: str | None = None):
+        self.output.insert(tk.END, text + "\n", tag or "")
+        self.output.see(tk.END)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="boss-gui",
+        description="BOSS直聘 抓取 + 摘要 桌面图形界面",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {boss.__version__}")
+    parser.parse_args(argv)
+    root = tk.Tk()
+    BossGui(root)
+    root.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_gui_chain.py
+++ b/tests/test_gui_chain.py
@@ -1,0 +1,161 @@
+"""boss_gui 薄壳的纯逻辑测试：命令行拼装 + 自动接跑摘要的判定。
+
+不创建窗口、不依赖 Chrome / 网络；只验证 GUI 不会把参数拼错。
+"""
+
+import importlib
+import os
+import sys
+import unittest
+from unittest import mock
+
+import scripts.boss_cdp_raw as boss_mod
+from scripts import boss_gui
+
+
+class BuildScrapeArgsTest(unittest.TestCase):
+    def test_defaults_json_no_detail_no_analysis(self):
+        args = boss_gui.build_scrape_args("AI Agent", "上海", 3)
+        self.assertEqual(args[0], sys.executable)
+        self.assertIn("--keyword", args)
+        self.assertEqual(args[args.index("--keyword") + 1], "AI Agent")
+        self.assertEqual(args[args.index("--city") + 1], "上海")
+        self.assertEqual(args[args.index("--pages") + 1], "3")
+        self.assertIn("--no-detail", args)
+        self.assertNotIn("--detail", args)
+        self.assertNotIn("--analysis", args)
+        self.assertNotIn("--format", args)  # json 是默认，不显式传
+
+    def test_csv_detail_analysis_and_custom_port(self):
+        args = boss_gui.build_scrape_args(
+            "Java", "北京", 5, cdp_port=9223, fmt="csv", detail=True, analysis=True,
+        )
+        self.assertEqual(args[args.index("--format") + 1], "csv")
+        self.assertEqual(args[args.index("--cdp-port") + 1], "9223")
+        self.assertIn("--detail", args)
+        self.assertNotIn("--no-detail", args)
+        self.assertIn("--analysis", args)
+
+    def test_output_and_merge(self):
+        args = boss_gui.build_scrape_args("Python", "深圳", 2, output=r"D:\r\a.json", merge=r"D:\r\old.json")
+        self.assertEqual(args[args.index("--output") + 1], r"D:\r\a.json")
+        self.assertEqual(args[args.index("--merge") + 1], r"D:\r\old.json")
+
+    def test_detail_output_flag(self):
+        args = boss_gui.build_scrape_args(
+            "Python", "上海", 1, detail=True,
+            output=r"D:\r\a.json", detail_output=r"D:\r\d.json",
+        )
+        self.assertEqual(args[args.index("--detail-output") + 1], r"D:\r\d.json")
+
+
+class BuildOtherArgsTest(unittest.TestCase):
+    def test_summary_args(self):
+        args = boss_gui.build_summary_args(top=15)
+        self.assertEqual(args[0], sys.executable)
+        self.assertEqual(args[args.index("--top") + 1], "15")
+
+    def test_summary_args_with_input(self):
+        args = boss_gui.build_summary_args(top=8, input_path=r"D:\r\multi.json")
+        self.assertEqual(args[args.index("--input") + 1], r"D:\r\multi.json")
+
+    def test_summary_args_with_result_dir(self):
+        args = boss_gui.build_summary_args(top=8, result_dir=r"D:\r")
+        self.assertEqual(args[args.index("--result-dir") + 1], r"D:\r")
+
+    def test_check_args(self):
+        args = boss_gui.build_check_args(9222)
+        self.assertIn("--check", args)
+        self.assertEqual(args[args.index("--cdp-port") + 1], "9222")
+
+    def test_setup_chrome_does_not_wait_for_login(self):
+        args = boss_gui.build_setup_chrome_args(9222)
+        self.assertIn("--setup-chrome", args)
+        self.assertIn("--no-wait-login", args)  # GUI 启动后立即返回，登录由用户完成
+
+    def test_smoke_and_stop_chrome(self):
+        self.assertIn("--smoke-test", boss_gui.build_smoke_args(9222))
+        self.assertIn("--stop-chrome", boss_gui.build_stop_chrome_args(9222))
+
+
+class AutoSummaryDecisionTest(unittest.TestCase):
+    def test_only_zero_exit_code_triggers_summary(self):
+        self.assertTrue(boss_gui.should_auto_summary(0))
+        self.assertFalse(boss_gui.should_auto_summary(1))
+        self.assertFalse(boss_gui.should_auto_summary(2))
+
+
+class SplitKeywordsTest(unittest.TestCase):
+    def test_splits_by_common_separators(self):
+        self.assertEqual(
+            boss_gui.split_keywords("AI Agent,Python，Java;产品经理；前端\n后端"),
+            ["AI Agent", "Python", "Java", "产品经理", "前端", "后端"],
+        )
+
+    def test_strips_and_ignores_empty(self):
+        self.assertEqual(boss_gui.split_keywords("  AI  ,  ,  Python  "), ["AI", "Python"])
+        self.assertEqual(boss_gui.split_keywords(""), [])
+        self.assertEqual(boss_gui.split_keywords("   "), [])
+
+
+class BuildMultiKeywordStepsTest(unittest.TestCase):
+    def test_single_keyword_explicit_output_no_merge(self):
+        steps, final_path, parts = boss_gui.build_multi_keyword_steps(
+            ["AI Agent"], "上海", 2, result_dir=r"D:\r", timestamp="20260823_1200",
+        )
+        self.assertEqual(len(steps), 1)
+        self.assertEqual(final_path, r"D:\r\boss_jobs_20260823_1200.json")
+        self.assertEqual(parts, [])
+        first_args, _ = steps[0]
+        self.assertNotIn("--merge", first_args)
+        self.assertEqual(first_args[first_args.index("--output") + 1], final_path)
+
+    def test_multi_keyword_chains_merge_and_returns_parts(self):
+        steps, final_path, parts = boss_gui.build_multi_keyword_steps(
+            ["AI", "Python", "Java"], "上海", 2,
+            result_dir=r"D:\r", timestamp="20260823_1200",
+        )
+        self.assertEqual(len(steps), 3)
+        self.assertEqual(final_path, r"D:\r\boss_jobs_20260823_1200_multi.json")
+        self.assertEqual(parts, [
+            r"D:\r\boss_jobs_20260823_1200_multi.part1.json",
+            r"D:\r\boss_jobs_20260823_1200_multi.part2.json",
+        ])
+        first_args, _ = steps[0]
+        self.assertNotIn("--merge", first_args)
+        self.assertEqual(first_args[first_args.index("--output") + 1], final_path)
+        second_args, _ = steps[1]
+        self.assertEqual(second_args[second_args.index("--merge") + 1], final_path)
+        self.assertEqual(second_args[second_args.index("--output") + 1], parts[0])
+        third_args, _ = steps[2]
+        self.assertEqual(third_args[third_args.index("--merge") + 1], parts[0])
+        self.assertEqual(third_args[third_args.index("--output") + 1], parts[1])
+
+    def test_multi_keyword_detail_outputs_are_distinct(self):
+        steps, _, _ = boss_gui.build_multi_keyword_steps(
+            ["AI", "Python"], "上海", 2, detail=True,
+            result_dir=r"D:\r", timestamp="20260823_1200",
+        )
+        first, second = steps[0][0], steps[1][0]
+        self.assertEqual(
+            first[first.index("--detail-output") + 1],
+            r"D:\r\boss_details_20260823_1200_multi.json",
+        )
+        self.assertEqual(
+            second[second.index("--detail-output") + 1],
+            r"D:\r\boss_details_20260823_1200_multi.part1.json",
+        )
+
+
+class DefaultResultDirEnvTest(unittest.TestCase):
+    def test_env_override_honored(self):
+        with mock.patch.dict(os.environ, {"BOSS_RESULT_DIR": r"D:\boss\job-result"}):
+            importlib.reload(boss_mod)
+            self.assertTrue(
+                boss_mod.DEFAULT_RESULT_DIR.replace("\\", "/").startswith("D:/boss/job-result")
+            )
+        importlib.reload(boss_mod)  # 环境变量已还原，重新计算默认值，避免影响后续用例
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

为项目新增 tkinter 桌面图形界面（零额外依赖），把「抓取 → 摘要」整条链路收进一个可视化窗口：填好关键词、城市、页数、结果目录后一键运行，抓取正常结束（exit 0）后自动接跑 `job_summary.py`；支持多关键词逐个抓取并自动合并去重，结果目录可通过环境变量或界面自定义。

## 为什么

- 命令行方式需要分两步跑 `boss_cdp_raw.py` 和 `job_summary.py`，参数全靠记忆，不熟悉 CLI 的用户上手成本高。
- 结果默认落在 `~/.boss-zhipin-scraper/job-result`（Windows 上在 C 盘），需要能存到自定义位置。
- 单一关键词一次只能搜一类岗位，求职分析常需要同时看多个方向并合并。

## 改了什么

- `scripts/boss_gui.py`（新增）：tkinter 图形界面
  - 参数表单：关键词（支持多个，英文/中文逗号、分号或换行分隔）、城市、页数、CDP 端口、JSON/CSV、详情页、分析报告、结果目录（含「浏览...」按钮）
  - 一键操作：环境检查、启动 Chrome、Smoke 测试、开始抓取、生成摘要、关闭 Chrome、停止
  - 抓取成功（exit 0）后按勾选自动运行 `job_summary.py`；失败/风控时跳过摘要，保留已抓数据
  - 多关键词：逐个抓取，后续关键词用 `--merge` 按 `job_id` 合并去重，最后对合并结果生成一份摘要
  - 子进程输出实时流式显示，任务结束恢复「就绪」；修复任务收尾事件解包错误（4 元组按 2 元组解包导致轮询器崩溃、状态卡死、自动摘要不触发）
- `scripts/boss_cdp_raw.py`：结果目录支持 `$BOSS_RESULT_DIR` 环境变量覆盖，默认值不变（`~/.boss-zhipin-scraper/job-result`）
- `pyproject.toml`：新增 `boss-gui` 命令入口
- `tests/test_gui_chain.py`（新增）：命令行拼装、多关键词拆分/合并链路、自动接跑摘要判定、环境变量覆盖等 17 个单测
- `README.md` / `README.en.md`：新增 GUI 章节、结果目录与多关键词说明；`CHANGELOG.md`、`AGENTS.md`、`.gitignore` 同步

未改动：核心抓取链路（列表被动捕获、详情、登录探测）行为不变，GUI 仅以子进程方式调用现有 CLI，不含抓取逻辑。

## 怎么测试的

- 本地全量单测通过：`python3 -m unittest tests.test_chrome_setup tests.test_job_summary tests.test_gui_chain`（113 个，全 mock，无需 Chrome/网络）
- `py_compile` 三个脚本通过
- 真机验证（已登录 Chrome / CDP 9222）：`--check` 通过；`--smoke-test` 通过；GUI 抓取 1 页 → 自动接跑摘要 → 正常收尾；自定义结果目录落盘验证（目录内仅生成一个合并结果 JSON）

## 影响范围

- 影响：GUI 使用流程、结果目录语义（新增 env 覆盖，默认不变）、摘要脚本 `--result-dir` 传递
- 不影响：CLI 原有参数与输出格式、列表/详情/登录抓取链路、城市码表

Fixes #70