### PR TITLE
feat: 支持 macOS Chromium 自动探测与登录态目录匹配

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - 删除死代码：`FETCH_API_JS_TEMPLATE`、`build_login_probe_url`、`parse_api_jobs_eval_value`、`should_use_dom_fallback`；`CDPSession` 新增事件缓冲与 `drain_events`；测试从 92 增至 96 个
 
 ### 新增
+- macOS 的 `--setup-chrome` 新增 Chromium 自动探测：未安装 Google Chrome 但存在 `/Applications/Chromium.app` 时，自动启动 Chromium；`--copy-login-state` 也会使用与所选浏览器匹配的 profile 目录。（#46）
 - 详情/列表结果新增独立字段 `boss_active_status`（如「今日活跃」「在线」）：列表兼容 `activeTimeDesc` 与 `bossOnline`（仅在线时映射为「在线」）；详情页从招聘者卡片解析更细粒度状态并优先保留；JD 正文仍剔除该行，不混入描述
 - 新增 `--stop-chrome` 命令：抓取/分析完成后关闭 BOSS 专用 CDP Chrome（按 user-data-dir 精准匹配隔离 profile，不碰主 Chrome）；抓取命令新增 `--close-chrome` 选项，正常结束后自动收尾（默认关闭，异常退出不触发以保留登录态）。复用已有 `stop_cdp_chrome` 的安全匹配逻辑，补齐进程关闭/收尾链路的单元测试。（#26）
 - 城市码表外置为 `data/city_codes.json`（全量 300+ 城市，覆盖一二三四五线），新增 `--list-cities [关键词]` 命令查看支持的城市；`resolve_city` 查询链改为「本地静态码表 → 运行时拉 BOSS 接口 → 9 位裸码兜底」。城市码表打进 wheel，`pip install` 用户也可用。（#24）

--- a/README.en.md
+++ b/README.en.md
@@ -52,9 +52,9 @@ Right after scraping you get: salary ranges, experience requirements, top skill 
 - Detail-page JD scraping + skill analysis
 - Aggregated summary + copy-paste prompt after scraping
 - Incremental writes (no data loss on crash)
-- One-shot environment check + persistent isolated Chrome CDP profile
+- One-shot environment check + persistent isolated Chrome/Chromium CDP profile
 - Multi-dimension filters (scale, funding, salary, experience, degree, industry)
-- macOS + Linux support; Windows is verified by unit tests and basic CLI checks (GBK console crash fixed), real scraping flows still welcome feedback
+- macOS + Linux support; macOS automatically detects Google Chrome or Chromium; Windows is verified by unit tests and basic CLI checks (GBK console crash fixed), real scraping flows still welcome feedback
 
 <details>
 <summary>🔍 Why not a Selenium / Playwright crawler?</summary>
@@ -134,6 +134,7 @@ pip install -r requirements.txt
 
 # 2. Start Chrome CDP
 python3 scripts/boss_cdp_raw.py --setup-chrome
+# macOS automatically selects an installed Google Chrome or /Applications/Chromium.app
 # First run won't copy your main Chrome session; log in to zhipin.com in the dedicated BOSS browser that pops up
 # setup waits for login to finish and confirms the API returns plaintext salaries
 
@@ -260,7 +261,11 @@ If you really need to import the BOSS session from your main Chrome, run explici
 python3 scripts/boss_cdp_raw.py --setup-chrome --copy-login-state
 ```
 
-`--copy-login-state` overwrites the corresponding cookie-related files inside the isolated profile on every run; do not pass this for daily launches. It only copies `Local State` and `Default/Cookies*`, `Default/Network/Cookies*`-style cookie database files — not password stores, history, extensions, or a full profile. To wipe the dedicated browser's login state:
+`--copy-login-state` overwrites the corresponding cookie-related files inside the isolated profile on every run; do not pass this for daily launches. It only copies `Local State` and `Default/Cookies*`, `Default/Network/Cookies*`-style cookie database files — not password stores, history, extensions, or a full profile.
+
+On macOS, the import source matches the browser selected automatically: Google Chrome uses `~/Library/Application Support/Google/Chrome`, while Chromium uses `~/Library/Application Support/Chromium`.
+
+To wipe the dedicated browser's login state:
 
 ```bash
 python3 scripts/boss_cdp_raw.py --setup-chrome --reset-chrome-profile

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ python3 scripts/job_summary.py
 - 详情页 JD 抓取 + 技能分析
 - 抓取后聚合摘要 + 可复制提示词
 - 增量写入（异常退出不丢数据）
-- 一键环境检查 + 持久隔离 Chrome CDP profile
+- 一键环境检查 + 持久隔离 Chrome/Chromium CDP profile
 - 多维筛选（规模、融资、薪资、经验、学历、行业）
-- macOS + Linux 支持；Windows 已通过单元测试与基础 CLI 验证（GBK 控制台崩溃已修复），真实抓取链路仍欢迎反馈
+- macOS + Linux 支持；macOS 会自动探测 Google Chrome 或 Chromium；Windows 已通过单元测试与基础 CLI 验证（GBK 控制台崩溃已修复），真实抓取链路仍欢迎反馈
 
 <details>
 <summary>🔍 为什么不选 Selenium / Playwright 类爬虫？</summary>
@@ -136,6 +136,7 @@ pip install -r requirements.txt
 
 # 2. 启动 Chrome CDP
 python3 scripts/boss_cdp_raw.py --setup-chrome
+# macOS 会自动选择已安装的 Google Chrome 或 /Applications/Chromium.app
 # 首次使用也不会复制主 Chrome 登录态；请在弹出的 BOSS 专用浏览器中登录 zhipin.com
 # setup 会等待登录完成，并确认接口能返回明文薪资
 
@@ -261,7 +262,11 @@ boss-zhipin-scraper/
 python3 scripts/boss_cdp_raw.py --setup-chrome --copy-login-state
 ```
 
-`--copy-login-state` 每次运行都会覆盖隔离 profile 内对应的 Cookie 相关文件；日常启动不要加这个参数。它只复制 `Local State` 和 `Default/Cookies*`、`Default/Network/Cookies*` 这类 Cookie 数据库相关文件，不复制密码库、历史记录、扩展或完整 profile。需要清空专用浏览器登录态时使用：
+`--copy-login-state` 每次运行都会覆盖隔离 profile 内对应的 Cookie 相关文件；日常启动不要加这个参数。它只复制 `Local State` 和 `Default/Cookies*`、`Default/Network/Cookies*` 这类 Cookie 数据库相关文件，不复制密码库、历史记录、扩展或完整 profile。
+
+macOS 上的导入源会与自动选中的浏览器保持一致：Google Chrome 使用 `~/Library/Application Support/Google/Chrome`，Chromium 使用 `~/Library/Application Support/Chromium`。
+
+需要清空专用浏览器登录态时使用：
 
 ```bash
 python3 scripts/boss_cdp_raw.py --setup-chrome --reset-chrome-profile

--- a/scripts/boss_cdp_raw.py
+++ b/scripts/boss_cdp_raw.py
@@ -64,10 +64,33 @@ CITY_GROUP_URL = "https://www.zhipin.com/wapi/zpCommon/data/cityGroup.json"
 MAX_PAGES = 10          # 单次最大页数
 MAX_API_REQUESTS = 500  # 单次最大 API 请求数
 
+
+MACOS_BROWSER_CANDIDATES = (
+    (
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "~/Library/Application Support/Google/Chrome",
+    ),
+    (
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "~/Library/Application Support/Chromium",
+    ),
+)
+
+
+def get_default_macos_browser_paths():
+    """Return matching executable/profile paths for an installed macOS browser."""
+    for executable, profile_dir in MACOS_BROWSER_CANDIDATES:
+        if os.path.exists(executable):
+            return executable, os.path.expanduser(profile_dir)
+
+    executable, profile_dir = MACOS_BROWSER_CANDIDATES[0]
+    return executable, os.path.expanduser(profile_dir)
+
+
 def get_default_chrome_path():
     system = platform.system()
     if system == "Darwin":
-        return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        return get_default_macos_browser_paths()[0]
     if system == "Windows":
         candidates = []
         local_app_data = os.environ.get("LOCALAPPDATA")
@@ -97,7 +120,7 @@ def get_default_chrome_path():
 def get_default_profile_dir():
     system = platform.system()
     if system == "Darwin":
-        return os.path.expanduser("~/Library/Application Support/Google/Chrome")
+        return get_default_macos_browser_paths()[1]
     if system == "Windows":
         base = os.environ.get("LOCALAPPDATA")
         if not base:

--- a/tests/test_chrome_setup.py
+++ b/tests/test_chrome_setup.py
@@ -1170,6 +1170,34 @@ class ChromeSetupTests(unittest.TestCase):
                 r"C:\Users\leon\AppData\Local\Google\Chrome\User Data",
             )
 
+    def test_macos_defaults_to_chromium_when_google_chrome_is_missing(self):
+        module = load_module()
+        chromium_path = "/Applications/Chromium.app/Contents/MacOS/Chromium"
+
+        with mock.patch.object(module.platform, "system", return_value="Darwin"), \
+                mock.patch.object(
+                    module.os.path,
+                    "exists",
+                    side_effect=lambda path: path == chromium_path,
+                ):
+            self.assertEqual(module.get_default_chrome_path(), chromium_path)
+            self.assertEqual(
+                module.get_default_profile_dir(),
+                module.os.path.expanduser("~/Library/Application Support/Chromium"),
+            )
+
+    def test_macos_prefers_google_chrome_when_both_browsers_are_installed(self):
+        module = load_module()
+        chrome_path = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+        with mock.patch.object(module.platform, "system", return_value="Darwin"), \
+                mock.patch.object(module.os.path, "exists", return_value=True):
+            self.assertEqual(module.get_default_chrome_path(), chrome_path)
+            self.assertEqual(
+                module.get_default_profile_dir(),
+                module.os.path.expanduser("~/Library/Application Support/Google/Chrome"),
+            )
+
     def test_windows_process_parsing_matches_user_data_dir_and_cdp_port(self):
         module = load_module()
         ps_json = json.dumps([{


### PR DESCRIPTION
## 问题与改动

macOS 仅安装 Chromium 时，`--setup-chrome` 原先仍使用 Google Chrome 的固定路径，导致无法启动。本 PR 按顺序探测 Google Chrome 和 `/Applications/Chromium.app`，两者均安装时继续优先选择 Google Chrome；均未安装时保留原默认路径。

`--copy-login-state` 的源 profile 目录随所选浏览器匹配：Chrome 使用 `~/Library/Application Support/Google/Chrome`，Chromium 使用 `~/Library/Application Support/Chromium`。同步更新中英文 README 和 CHANGELOG。

## 验证

- `python -m unittest tests.test_chrome_setup tests.test_job_summary`：98 项测试通过，包含仅安装 Chromium 和同时安装两种浏览器的场景。
- `python -m py_compile scripts/boss_cdp_raw.py scripts/job_summary.py`：通过。
- `git diff --check`：通过。
- 未进行真实浏览器启动及抓取验证。

Closes #46
